### PR TITLE
Add Codex++ product research map

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,39 @@
+# Codex++ Product Research
+
+This folder is the working product/reverse-engineering map for Codex++.
+
+## Structure
+
+- `agents/`: one note per exploration lane, written by the agent that owned it.
+- `synthesis/`: integrated product roadmap, constraints, and prioritization.
+- `evidence/`: exact commands, local observations, protocol facts, and bundle anchors.
+
+## Scoring
+
+Each idea should be tagged with:
+
+- `Impact`: low, medium, high, or moonshot.
+- `Effort`: small, medium, large, or research.
+- `Confidence`: low, medium, or high.
+- `Dependency`: native Codex seam, Codex++ runtime seam, app-server protocol, or external service.
+
+## Current Context
+
+Stable Codex.app is patched with Codex++ against Codex Desktop
+`26.429.20946`. Beta Codex is patched separately at
+`/Applications/Codex (Beta).app` against `26.429.21146`. Both embedded
+app-servers report `codex-cli 0.128.0-alpha.1` and include the `goals`
+feature flag. Codex++ now has in-flight support for:
+
+- `/goal` frontend handling via a preload bridge to `thread/goal/*`.
+- A composer-anchored `/goal` command suggestion shim.
+- A read-only git metadata provider exposed through `api.git` with the
+  `git.metadata` tweak permission.
+- Dual stable/beta patching through separate Codex++ homes and shared tweaks.
+
+## Integrated Outputs
+
+- `synthesis/product-roadmap.md`: ordered product plan.
+- `synthesis/constraints-map.md`: stable seams, hard constraints, and product consequences.
+- `evidence/current-state.md`: exact installed app/config/repo verification.
+- `evidence/dual-channel-patching.md`: stable/beta patch commands and findings.

--- a/research/agents/README.md
+++ b/research/agents/README.md
@@ -1,0 +1,26 @@
+# Agent Research Notes
+
+Each file in this folder is owned by one exploration lane. Keep notes ordered:
+
+1. Best immediate wins.
+2. Medium bets.
+3. Wild ideas or moonshots.
+4. Constraints and exact evidence.
+5. Suggested next slice.
+
+## Notes
+
+- `app-server-api.md`: app-server methods, typed wrapper opportunities, and goal/config/thread API shape.
+- `automation-qa.md`: remote debugging, Playwright/CDP proof, screenshots, and smoke scripts.
+- `bundle-map.md`: installed stable/beta bundle chunks and UI integration seams.
+- `easy-wins.md`: short-horizon product slices.
+- `git-sidebar.md`: git metadata in sidebar/filelist/product surfaces.
+- `goal-workflows.md`: `/goal` UX, persistence, budgets, templates, and completion reports.
+- `multi-agent-workflows.md`: ledgers, subagent inboxes, handoffs, spawn planning, and worktrees.
+- `native-ui.md`: native-feeling UI strategy and surface selection.
+- `observability.md`: runtime health, logs, app-server timelines, and trace ideas.
+- `onboarding-settings.md`: Recovery Center, safe mode, MCP preview, and onboarding.
+- `runtime-architecture.md`: Codex++ layer map, extension contracts, and platform risks.
+- `security-boundaries.md`: capability policy and trust boundaries.
+- `tweak-ecosystem.md`: catalog, permissions, provenance, updates, and developer mode.
+- `update-resilience.md`: Sparkle drift, watcher health, repair UX, and compatibility canaries.

--- a/research/agents/app-server-api.md
+++ b/research/agents/app-server-api.md
@@ -1,0 +1,555 @@
+# App-Server API Research Notes
+
+Owner scope: this note only. Evidence was gathered from the local
+`/Users/af/codex-plusplus` checkout, the installed `/Applications/Codex.app`
+bundle, the local `codex`/embedded Codex binary, and local Codex config/cache
+files.
+
+## 1. Evidence Baseline
+
+1. Installed app and CLI state:
+   - `codexplusplus status` reports Codex++ `0.1.4` patched into
+     `/Applications/Codex.app`, Codex Desktop `26.429.20946`, stable channel,
+     bundle id `com.openai.codex`, patched asar hash OK, and asar fuse off.
+   - `/Applications/Codex.app/Contents/Resources/codex --version` reports
+     `codex-cli 0.128.0-alpha.1`.
+   - `/opt/homebrew/bin/codex --version` reports `codex-cli 0.128.0`.
+   - `codex debug app-server --help` exposes only one debug subcommand:
+     `send-message-v2 <USER_MESSAGE>`. It does not expose a method catalog.
+
+2. Codex++ runtime bridge evidence:
+   - `packages/runtime/src/preload/app-server-bridge.ts` sends IPC messages on
+     `codex_desktop:message-from-view` with `{ type: "mcp-request", hostId,
+     request: { id, method, params } }`.
+   - The same bridge receives `codex_desktop:message-for-view` and accepts
+     response envelopes in these shapes: `mcp-response`, `mcp-error`, raw
+     `{ type: "response", id }`, or raw JSON-RPC-ish `{ id, result | error }`.
+   - It treats app-server pushes as notifications when the envelope is
+     `mcp-notification` or any method-only message with no `id`.
+   - Default request timeout is 12 seconds. This matters for fs, config, MCP,
+     and remote host calls.
+
+3. Current Codex++ tweak surface:
+   - `packages/sdk/src/index.ts` exposes `storage`, `log`, `settings`, `react`,
+     scoped `ipc`, sandboxed `fs`, optional main-only `codex`, and optional
+     `git`.
+   - Tweak permissions are currently:
+     `ipc`, `filesystem`, `network`, `settings`, `codex.windows`,
+     `codex.views`, `git.metadata`.
+   - `packages/runtime/src/preload/tweak-host.ts` only exposes `api.git` to
+     renderer tweaks that declare `git.metadata`.
+   - `packages/runtime/src/main.ts` exposes native Codex windows/views through
+     internal `__codexpp_window_services__`, with `createWindow()` and
+     `createBrowserView()` registered into Codex host context.
+   - `packages/runtime/src/mcp-sync.ts` syncs tweak `manifest.mcp` declarations
+     into `~/.codex/config.toml` under a managed block, preserving manual MCP
+     config outside the block.
+
+4. Current goal implementation evidence:
+   - `packages/runtime/src/preload/goal-feature.ts` already calls
+     `thread/goal/get`, `thread/goal/set`, and `thread/goal/clear`.
+   - It subscribes to `thread/goal/updated` and `thread/goal/cleared`.
+   - It extracts `threadId` by scanning `location.pathname`, hash, href,
+     `initialRoute`, and recursive `history.state` candidates for `/local/<id>`.
+   - Its user-facing errors prove known native constraints: `[features].goals`
+     may be disabled, `experimentalApi` negotiation may be required, and older
+     app-server builds may not support `thread/goal/*`.
+
+5. App bundle and binary method evidence:
+   - `npx asar list /Applications/Codex.app/Contents/Resources/app.asar` shows
+     renderer chunks for `app-server-manager-hooks`, `app-server-manager-signals`,
+     `config-queries`, `experimental-features-queries`, `mcp-settings`, and
+     thread pages.
+   - The asar main chunk defines the same IPC channel names:
+     `codex_desktop:message-from-view`, `codex_desktop:message-for-view`,
+     `codex_desktop:mcp-app-sandbox-guest-message`, and
+     `codex_desktop:mcp-app-sandbox-host-message`.
+   - Binary strings in `/Applications/Codex.app/Contents/Resources/codex`
+     include source anchors for `app-server-protocol/src/protocol/v2.rs`,
+     `app-server/src/config_api.rs`, `external_agent_config_api.rs`,
+     `fs_api.rs`, `fs_watch.rs`, `command_exec.rs`,
+     `thread_goal_handlers.rs`, `plugins.rs`, and app/MCP helpers.
+
+6. Local config and schema/cache evidence:
+   - `~/.codex/config.toml` has `[features]` entries for `apps`,
+     `apps_mcp_gateway`, `goals`, `multi_agent`, `plugins`,
+     `realtime_conversation`, `shell_tool`, `unified_exec`, and other flags.
+   - The same config has `[apps._default]` controls:
+     `enabled`, `destructive_enabled`, and `open_world_enabled`.
+   - The same config has `[agents]` controls:
+     `job_max_runtime_seconds`, `max_depth`, and `max_threads`.
+   - `~/.codex/cache/codex_apps_tools/*.json` files are local app-tool schema
+     caches with top-level `schema_version` and `tools`.
+
+## 2. Native App-Server Surface Seen Locally
+
+1. Thread and turn methods seen in binary strings:
+   - `thread/start`
+   - `thread/resume`
+   - `thread/fork`
+   - `thread/archive`
+   - `thread/unarchive`
+   - `thread/unsubscribe`
+   - `thread/list`
+   - `thread/loaded/list`
+   - `thread/read`
+   - `thread/turns/list`
+   - `thread/inject_items`
+   - `thread/name/set`
+   - `thread/metadata/update`
+   - `thread/memoryMode/set`
+   - `thread/compact/start`
+   - `thread/shellCommand`
+   - `thread/backgroundTerminals/clean`
+   - `thread/rollback`
+   - `thread/approveGuardianDeniedAction`
+   - `turn/start`
+   - `turn/steer`
+   - `turn/interrupt`
+   - `review/start`
+
+2. Goal methods and notifications seen in binary strings and current code:
+   - Requests: `thread/goal/set`, `thread/goal/get`, `thread/goal/clear`.
+   - Notifications: `thread/goal/updated`, `thread/goal/cleared`.
+   - Response type strings include `ThreadGoalGetResponse`,
+     `ThreadGoalSetResponse`, and `ThreadGoalClearResponse`.
+
+3. Filesystem methods seen in binary strings:
+   - `fs/readFile`
+   - `fs/readDirectory`
+   - `fs/writeFile`
+   - `fs/createDirectory`
+   - `fs/getMetadata`
+   - `fs/remove`
+   - `fs/copy`
+   - `fs/watch`
+   - `fs/unwatch`
+   - Notification: `fs/changed`.
+   - Binary error string: `fs/writeFile requires valid base64 dataBase64`,
+     so writes are not plain text-only at the native boundary.
+
+4. Config and feature methods seen in binary/asar strings:
+   - `config/read`
+   - `config/value/write`
+   - `config/batchWrite`
+   - `configRequirements/read`
+   - `config/mcpServer/reload`
+   - `experimentalFeature/list`
+   - `experimentalFeature/enablement/set`
+   - The Desktop `config-queries` chunk wraps these as:
+     `read-config-for-host`, `write-config-value`,
+     `batch-write-config-value`, and `get-config-requirements-for-host`.
+
+5. External agent methods seen in binary/asar strings:
+   - `externalAgentConfig/detect`
+   - `externalAgentConfig/import`
+   - Notification: `externalAgentConfig/import/completed`.
+   - Config strings also show `local-custom-agents`, `agents`, `roles`, and
+     agent-role config paths.
+
+6. Apps, plugins, MCP, and marketplace methods seen locally:
+   - Apps: `app/list`, notification `app/list/updated`.
+   - Plugins: `plugin/list`, `plugin/read`, `plugin/install`,
+     `plugin/uninstall`.
+   - Skills/hooks/marketplace: `skills/list`, `skills/config/write`,
+     `hooks/list`, `marketplace/add`, `marketplace/remove`,
+     `marketplace/upgrade`.
+   - MCP: `mcpServer/oauth/login`, `mcpServerStatus/list`,
+     `mcpServer/resource/read`, `mcpServer/tool/call`,
+     `config/mcpServer/reload`.
+   - MCP notifications include OAuth login completion, server status updates,
+     and tool-call progress.
+
+7. Command execution methods seen locally:
+   - `command/exec`
+   - `command/exec/write`
+   - `command/exec/terminate`
+   - `command/exec/resize`
+   - Notification: `command/exec/outputDelta`.
+   - Response type strings include `CommandExecResponse`,
+     `CommandExecWriteResponse`, `CommandExecTerminateResponse`, and
+     `CommandExecResizeResponse`.
+
+8. Notifications seen in binary type strings:
+   - Thread lifecycle: started, archived, unarchived, closed, name updated,
+     status changed, token usage updated.
+   - Turn lifecycle: started, completed, diff updated, plan updated.
+   - Item streams: agent message delta, plan delta, reasoning deltas, raw
+     response item completion, file-change deltas, command-output deltas.
+   - MCP/app/config: app list updated, MCP status updated, MCP OAuth completed,
+     MCP tool-call progress, config warning.
+   - System/account/model: warning, guardian warning, deprecation notice,
+     account updates, rate-limit updates, model reroute/verification.
+   - Realtime: start, item added, transcript deltas/done, output audio delta,
+     SDP, error, closed.
+
+## 3. Product Ideas For What Codex++ Should Expose To Tweaks
+
+1. `api.appServer.request()` as an advanced, permission-gated escape hatch.
+   - Impact: high.
+   - Effort: small to medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam plus app-server protocol.
+   - Proposed shape:
+     `request<T>(method: string, params: unknown, options?: { hostId?: string; timeoutMs?: number }): Promise<T>`.
+   - Gate behind a new manifest permission such as `codex.appServer.raw`.
+   - Default to deny in examples. Encourage typed wrappers first.
+   - Add method allowlists per permission so raw access can be reviewed.
+
+2. `api.thread` typed wrapper for read-mostly thread metadata and lifecycle.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: app-server protocol.
+   - Expose safe reads first:
+     `list`, `loadedList`, `read`, `turnsList`, `getCurrentThreadId`,
+     `onThreadStatusChanged`, `onTurnCompleted`, `onTokenUsageUpdated`.
+   - Defer mutating methods (`start`, `resume`, `fork`, `archive`,
+     `inject_items`, `rollback`, `compact/start`) until there is a clear
+     permission and UX confirmation model.
+   - Product use: richer sidebars, thread dashboards, token/budget monitors,
+     checkpoint views, resume-state badges, recent-thread search, and
+     "open thread in new Codex window" actions.
+
+3. `api.goal` wrapper as the first productionized app-server feature.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: current Codex++ runtime seam plus `features.goals`.
+   - Current `/goal` feature proves the method path. Generalize it for tweaks:
+     `get(threadId)`, `set(threadId, patch)`, `clear(threadId)`,
+     `onUpdated`, and `onCleared`.
+   - Add `api.appServer.features.has("goals")` or a failure classifier so
+     tweaks can degrade cleanly when the app-server lacks the method or the
+     feature flag is off.
+   - Product use: persistent goal widgets, goal-aware notifications, token
+     budget dashboards, and "complete goal when checks pass" automations.
+
+4. `api.config` wrapper for safe config inspection and constrained writes.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: app-server protocol plus config write-risk policy.
+   - Read wrapper:
+     `read({ hostId, cwd, includeLayers })`,
+     `requirements({ hostId })`,
+     `listExperimentalFeatures({ hostId })`.
+   - Write wrapper:
+     `writeValue({ keyPath, value, mergeStrategy, target })` and
+     `batchWrite(...)`, but only for declared key prefixes.
+   - First allowed prefixes:
+     `features.<name>`, `mcp_servers.<name>.*`, maybe app settings under
+     `apps.<id>.*`.
+   - Product use: feature-flag toggles, MCP server manager, config provenance
+     viewer, workspace-specific config editor.
+   - Constraint: Desktop chunks compute write targets from layered config and
+     expected versions. Codex++ should reuse app-server config write APIs
+     rather than directly editing TOML when possible.
+
+5. `api.fsNative` wrapper separate from current Codex++ tweak sandbox `api.fs`.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: app-server protocol and permissions.
+   - Current `api.fs` is per-tweak storage under Codex++ user data. Keep that.
+   - Native fs API should be explicit and permission-gated, for example
+     `codex.fs.readonly` and `codex.fs.write`.
+   - Start with:
+     `readFile`, `readDirectory`, `getMetadata`, `watch`, `unwatch`,
+     `onChanged`.
+   - Writes (`writeFile`, `createDirectory`, `remove`, `copy`) should require
+     a stronger permission and probably user confirmation unless scoped to the
+     active workspace.
+   - Product use: file tree overlays, document previews, generated artifact
+     watchers, route-level reloads, "show changed files" panels.
+   - Constraint: native `fs/writeFile` expects base64 data, so SDK wrappers
+     should own encoding/decoding and byte limits.
+
+6. `api.commands` wrapper for terminal/command sessions.
+   - Impact: medium to high.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: app-server protocol and safety/approval policy.
+   - Start read-only around notifications:
+     command output deltas, command termination, current running command state.
+   - Mutating commands (`command/exec`, write stdin, resize, terminate) need
+     explicit permission, visible UI, and clear ownership of approval flow.
+   - Product use: terminal panel tweaks, run/test dashboards, command receipts,
+     "rerun failed check" buttons, and proof collection.
+   - Constraint: Codex already has approval/reviewer semantics. Codex++ should
+     not bypass them from tweaks.
+
+7. `api.notifications` event bus.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: current Codex++ app-server bridge.
+   - Expose a typed `on(method, handler)` and lower-level `onAny`.
+   - Add helper subscriptions:
+     `onThread`, `onTurn`, `onCommand`, `onMcp`, `onFs`, `onConfigWarning`.
+   - Product use: live dashboards, badges, toast integrations, background
+     automations, goal progress, and route refresh without polling.
+   - Constraint: notifications are host-scoped. The SDK should always surface
+     `hostId` context when available and let tweaks filter.
+
+8. `api.externalAgents` wrapper for import/detect workflows.
+   - Impact: medium.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: app-server protocol plus config semantics.
+   - Expose:
+     `detect({ hostId, cwd? })`, `import(...)`,
+     `onImportCompleted`, and read-only custom agent role lists.
+   - Product use: "import Cursor/Claude/Codex agent config" affordances,
+     agent-role dashboards, per-workspace agent templates, migration assistant.
+   - Constraint: agent config can touch user-level config. Treat as a
+     high-risk write path, not a silent tweak operation.
+
+9. `api.apps` and `api.mcp` wrappers.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: app-server protocol, local app schema cache, MCP config.
+   - Apps:
+     `list`, `onListUpdated`, maybe app enablement helpers via `api.config`.
+   - MCP:
+     `listServerStatus`, `readResource`, `callTool`, `oauthLogin`,
+     `reloadConfig`, `onServerStatusUpdated`, `onToolCallProgress`.
+   - Product use: app/plugin marketplace panels, MCP health dashboard, OAuth
+     repair flows, resource browser, tool-call inspectors.
+   - Constraint: MCP tool calls can be destructive or auth-sensitive. Respect
+     app config fields like `destructive_enabled`, `open_world_enabled`, and
+     per-tool approval modes.
+
+10. `api.codex.windows` should be linked to thread/app-server wrappers.
+    - Impact: medium.
+    - Effort: small.
+    - Confidence: high.
+    - Dependency: existing Codex++ runtime seam.
+    - Existing `createWindow` and `createBrowserView` need convenience helpers:
+      `openThread(threadId)`, `openRoute(route, hostId)`, and maybe
+      `openCurrentThreadClone()`.
+    - Product use: detachable goal dashboards, PR/review secondary windows,
+      multi-thread monitor, app/MCP admin pages.
+
+## 4. Constraints And Guardrails
+
+1. Native protocol stability is not guaranteed.
+   - The only stable thing Codex++ owns today is the IPC bridge shape and its
+     wrappers. Method names come from local binary/asar evidence, not a public
+     versioned SDK.
+   - Every typed wrapper should feature-detect by attempting a safe read or
+     checking `experimentalFeature/list`, then cache the capability by
+     `hostId + appServerVersion`.
+
+2. Host identity is first-class.
+   - Current bridge defaults `hostId` to the URL search param or `local`.
+   - Desktop supports remote connections and remote-control state. Tweaks
+     should not assume `local` when acting on current routes.
+
+3. Thread id discovery is currently route-derived.
+   - `goal-feature.ts` proves route scanning works for `/local/<id>`, but this
+     is a UI heuristic.
+   - Better product seam: expose `api.thread.current()` from Codex Desktop
+     manager state when possible, with the route heuristic as fallback.
+
+4. Some APIs are config- or negotiation-gated.
+   - `goals` can be disabled in `~/.codex/config.toml`.
+   - Goal calls may require `experimentalApi` negotiation.
+   - Apps/plugins/MCP depend on feature flags and installed connectors.
+   - Product UI should show "unsupported", "disabled", and "permission denied"
+     as distinct states.
+
+5. Do not collapse two filesystem concepts.
+   - Codex++ `api.fs` is tweak-private data storage.
+   - Native app-server `fs/*` is workspace/user filesystem access.
+   - Names and permissions should keep these separate to avoid accidental data
+     exposure.
+
+6. Do not bypass Codex safety.
+   - Command exec, file writes/removes, MCP tool calls, plugin installs, config
+     imports, and agent imports are high-blast-radius.
+   - Codex++ should route through app-server approvals and visible UI instead
+     of silent main-process shortcuts.
+
+7. Watchers and notifications need cleanup handles.
+   - `fs/watch` implies `fs/unwatch`.
+   - Tweak hot reload already calls `stop()`. App-server subscriptions should
+     register teardown functions so reloads do not leak event handlers.
+
+8. In-memory app-server state can outlive config edits.
+   - Prior local recovery notes observed that changing config does not salvage
+     an already-full in-memory thread; new sessions see config changes more
+     reliably than saturated existing threads.
+   - Product copy should avoid promising that config/feature changes mutate
+     every active thread immediately.
+
+9. Local caches are useful but not authority.
+   - `~/.codex/cache/codex_apps_tools/*.json` gives app tool schema snapshots,
+     but app-server and configured apps can change. Treat cache as a UI seed,
+     then refresh through `app/list` and MCP status APIs.
+
+## 5. Recommended Codex++ API Shape
+
+1. Add `AppServerApi` to the SDK:
+
+   ```ts
+   export interface AppServerApi {
+     request<T = unknown>(
+       method: string,
+       params?: unknown,
+       options?: { hostId?: string; timeoutMs?: number },
+     ): Promise<T>;
+     on(
+       method: string,
+       handler: (params: unknown, context: AppServerEventContext) => void,
+     ): () => void;
+     onAny(
+       handler: (event: AppServerEvent) => void,
+     ): () => void;
+   }
+   ```
+
+2. Add focused wrappers over the raw API:
+
+   ```ts
+   export interface CodexNativeApi {
+     appServer?: AppServerApi;
+     thread?: ThreadApi;
+     goal?: GoalApi;
+     config?: ConfigApi;
+     fsNative?: NativeFsApi;
+     commands?: CommandApi;
+     notifications?: NotificationApi;
+     externalAgents?: ExternalAgentsApi;
+     apps?: AppsApi;
+     mcp?: McpApi;
+   }
+   ```
+
+3. Add permission strings by area:
+   - `codex.appServer.raw`
+   - `codex.thread.read`
+   - `codex.thread.write`
+   - `codex.goal`
+   - `codex.config.read`
+   - `codex.config.write`
+   - `codex.fs.read`
+   - `codex.fs.write`
+   - `codex.commands.read`
+   - `codex.commands.exec`
+   - `codex.notifications`
+   - `codex.externalAgents`
+   - `codex.apps.read`
+   - `codex.mcp.read`
+   - `codex.mcp.call`
+
+4. Keep `git.metadata` as a separate domain.
+   - The current git provider is metadata-only and implemented in Codex++ main
+     process, not app-server.
+   - It should remain separate until native app-server git coverage is richer
+     than `thread.gitInfo` and `gitDiffToRemote`.
+
+5. Build wrappers as progressive capability objects.
+   - Example:
+     `api.goal` exists only when the tweak has permission and the runtime can
+     route app-server requests.
+   - `api.goal.capabilities()` should return support states:
+     `available`, `feature-disabled`, `unsupported`, `permission-denied`,
+     `host-unavailable`.
+
+## 6. Prioritized Implementation Slices
+
+1. Slice A: expose notifications and raw request behind permissions.
+   - Add SDK types for `AppServerApi`.
+   - Wire renderer API to existing `requestAppServer` and
+     `onAppServerNotification`.
+   - Add manifest validation for `codex.appServer.raw` and
+     `codex.notifications`.
+   - Acceptance: a local test tweak can call a harmless read method and listen
+     to a notification, then unload cleanly.
+
+2. Slice B: productize `api.goal`.
+   - Move goal request/notification code behind a typed SDK wrapper.
+   - Keep the existing `/goal` UI using the wrapper.
+   - Add capability/error classification.
+   - Acceptance: `/goal` behavior remains unchanged, and a tweak can render a
+     goal widget without reimplementing method strings.
+
+3. Slice C: config and feature flag panel.
+   - Add read-only `api.config.read` and `api.config.listExperimentalFeatures`.
+   - Add guarded write support for feature flags and MCP enabled flags.
+   - Acceptance: a tweak can display effective config provenance and toggle a
+     low-risk feature through app-server `batchWrite`, not direct TOML edits.
+
+4. Slice D: apps/MCP admin API.
+   - Add `api.apps.list`, `api.mcp.listServerStatus`, `api.mcp.readResource`,
+     and `api.mcp.reloadConfig`.
+   - Defer `api.mcp.callTool` until approval and destructive-tool UX is clear.
+   - Acceptance: MCP status dashboard can render server auth/health and react
+     to status notifications.
+
+5. Slice E: native fs read/watch.
+   - Add read-only `fsNative` plus watch/unwatch.
+   - Keep writes out of scope until permissions/confirmation are designed.
+   - Acceptance: a tweak can watch active workspace files and refresh UI on
+     `fs/changed`, with cleanup on tweak stop.
+
+6. Slice F: command read model.
+   - Subscribe to command output/terminal notifications and expose structured
+     command receipts.
+   - Defer execution controls.
+   - Acceptance: a tweak can show running command output without starting or
+     terminating commands.
+
+## 7. Open Questions
+
+1. Can Codex++ access Desktop's app-server manager instance directly enough to
+   read current thread and host identity without route heuristics?
+
+2. Is `experimentalApi` negotiation controlled by Desktop client info, feature
+   flags, or both? The existing goal error path proves the failure mode but not
+   the negotiation hook.
+
+3. Which app-server methods are safe on remote hosts? Config, fs, command, and
+   MCP calls may have different remote-host permission behavior.
+
+4. Does `experimentalFeature/enablement/set` persist to config or only mutate
+   session state? Desktop's experimental-features chunk writes via
+   `batch-write-config-value`, but the binary also exposes a direct enablement
+   method.
+
+5. Should tweak-provided MCP servers remain synced through Codex++'s TOML
+   managed block, or should future versions call app-server config APIs to add
+   them with provenance and expected-version checks?
+
+6. What is the app-server payload schema for `thread/start`, `turn/start`, and
+   `command/exec` in this build? Binary method names prove existence, but a
+   wrapper needs exact field contracts before exposing mutations.
+
+7. Should Codex++ expose app/plugin install/uninstall at all? It is powerful
+   but crosses from "tweak" into package manager and auth territory.
+
+## 8. Next Evidence To Collect
+
+1. Attach to a running Codex renderer and capture one harmless app-server
+   request/response pair for:
+   - `thread/list`
+   - `thread/read`
+   - `config/read`
+   - `experimentalFeature/list`
+   - `mcpServerStatus/list`
+
+2. Test `thread/goal/get` with goals enabled and then disabled to lock the
+   exact error strings for capability classification.
+
+3. Inspect app-server manager state in the renderer to find a non-route
+   current-thread source.
+
+4. Use a local throwaway tweak to verify whether raw app-server notification
+   subscriptions survive hot reload and whether teardown fully removes
+   listeners.
+
+5. Extract field-level schemas from app-server protocol artifacts if a
+   generated TypeScript export or JSON schema exists in a future build. Current
+   local evidence exposes method and type names, not all request payload fields.

--- a/research/agents/automation-qa.md
+++ b/research/agents/automation-qa.md
@@ -1,0 +1,469 @@
+# Automation QA And Product Proof Notes
+
+Scope: Codex++ testing and product-proof systems only. This file is the owned output for the automation QA lane.
+
+## 1. Best Immediate Wins
+
+### 1.1 Add a CDP-backed product proof harness
+
+Codex++ already has the right runtime seam for this: `packages/runtime/src/main.ts` can enable Chromium remote debugging with `CODEXPP_REMOTE_DEBUG=1` and `CODEXPP_REMOTE_DEBUG_PORT`, then appends Electron's `remote-debugging-port` switch before app readiness. That means the proof harness should connect to the real patched Codex renderer instead of launching a fake browser.
+
+Recommended first script:
+
+```sh
+scripts/qa/cdp-proof.mjs
+```
+
+Recommended command shape:
+
+```sh
+CODEXPP_REMOTE_DEBUG=1 CODEXPP_REMOTE_DEBUG_PORT=9222 open -n /Applications/Codex.app
+curl -fsS http://127.0.0.1:9222/json/version | jq .
+curl -fsS http://127.0.0.1:9222/json/list | jq '.[] | {id,type,title,url,webSocketDebuggerUrl}'
+node scripts/qa/cdp-proof.mjs --endpoint http://127.0.0.1:9222 --out research/evidence/cdp/$(date +%Y%m%d-%H%M%S)
+```
+
+Minimum script behavior:
+
+- Poll `http://127.0.0.1:<port>/json/list` until a target with `app://-/index.html` appears.
+- Attach with Playwright `chromium.connectOverCDP(endpoint)` for high-level actions and screenshots.
+- Create a raw CDP session for low-level facts that Playwright does not expose cleanly.
+- Save `targets.json`, `version.json`, `console.ndjson`, `preload-log-tail.txt`, `main-log-tail.txt`, `dom.html`, `accessibility.json`, and screenshots.
+- Fail if no target is found, no `[codex-plusplus preload] boot complete` appears, the settings sidebar lacks `Codex++`, or screenshots are blank.
+
+Why Playwright first: official Playwright supports attaching to an existing browser over CDP with `chromium.connectOverCDP("http://localhost:9222")`. It is lower fidelity than Playwright's own protocol, but this repo needs to drive a production Electron app that already exists. Raw CDP stays available for precise calls like `Page.captureScreenshot`, `Runtime.evaluate`, `Log.enable`, and `DOMSnapshot.captureSnapshot`.
+
+Useful primary docs:
+
+- Electron command-line switch: https://www.electronjs.org/docs/latest/api/command-line
+- Playwright CDP attach: https://playwright.dev/docs/api/class-browsertype
+- Chrome DevTools Protocol `Page.captureScreenshot`: https://chromedevtools.github.io/devtools-protocol/1-3/Page/#method-captureScreenshot
+- Playwright screenshots: https://playwright.dev/docs/screenshots
+- Playwright traces: https://playwright.dev/docs/trace-viewer-intro
+
+### 1.2 Make preload logs a first-class pass/fail signal
+
+Runtime preload already mirrors renderer progress to disk through `ipcRenderer.send("codexpp:preload-log", ...)` and `ipcMain.on("codexpp:preload-log", ...)`. Treat that as the fastest reliable smoke check because production Codex disables in-window DevTools.
+
+Exact commands:
+
+```sh
+tail -n 200 "$HOME/Library/Application Support/codex-plusplus/log/main.log"
+tail -n 200 "$HOME/Library/Application Support/codex-plusplus/log/preload.log"
+rg -n "remote debugging enabled|preload registered|web-contents-created|boot complete|boot FAILED|preload-error|tweak load failed" "$HOME/Library/Application Support/codex-plusplus/log"
+```
+
+Recommended script:
+
+```sh
+scripts/qa/preload-log-smoke.mjs --root "$HOME/Library/Application Support/codex-plusplus" --since-minutes 10
+```
+
+Pass criteria:
+
+- `main.log` contains `main.ts evaluated`.
+- `main.log` contains `preload registered`.
+- `main.log` contains at least one `web-contents-created`.
+- `preload.log` contains `preload entry`, `react hook installed`, `settings injector started`, `tweak host started`, and `boot complete`.
+- No matching `boot FAILED`, `preload-error`, `tweak load failed`, `uncaughtException`, or `unhandledRejection` after the selected start time.
+
+The log checker should output JSON for PR evidence:
+
+```json
+{
+  "ok": true,
+  "checkedAt": "2026-05-01T00:00:00.000Z",
+  "root": "/Users/af/Library/Application Support/codex-plusplus",
+  "requiredMarkers": ["preload registered", "boot complete"],
+  "forbiddenMarkers": [],
+  "files": ["main.log", "preload.log"]
+}
+```
+
+### 1.3 Smoke-test the app patch before any visual flow
+
+Patch correctness is a separate lane from renderer UI proof. Always run these before CDP screenshots:
+
+```sh
+node packages/installer/dist/cli.js status
+node packages/installer/dist/cli.js doctor
+node packages/installer/dist/cli.js validate-tweak "$HOME/Library/Application Support/codex-plusplus/tweaks/<tweak-id>"
+```
+
+Useful deeper macOS probes:
+
+```sh
+plutil -p "/Applications/Codex.app/Contents/Info.plist" | rg -n "ElectronAsarIntegrity|CFBundleIdentifier|CFBundleShortVersionString"
+codesign --verify --deep --strict --verbose=2 /Applications/Codex.app
+codesign -dv --verbose=4 /Applications/Codex.app 2>&1 | rg -n "Authority|TeamIdentifier|Signature"
+launchctl list | rg codexplusplus
+tail -n 200 "$HOME/Library/Logs/codex-plusplus-watcher.log"
+```
+
+Recommended script:
+
+```sh
+scripts/qa/app-patch-smoke.mjs --app /Applications/Codex.app --json research/evidence/app-patch-smoke.json
+```
+
+Pass criteria:
+
+- `status` reports a user dir, tweak dir, log dir, install state, and current app metadata.
+- `doctor` exits zero.
+- Current asar hash matches the patched hash or the script reports a repair-needed state explicitly.
+- `Info.plist` integrity hash matches the current asar header hash on macOS.
+- macOS code signature verifies after ad-hoc signing.
+- Watcher is present unless the install state records `watcher: none`.
+
+### 1.4 Add slash-command QA for `/goal`
+
+The current preload includes a slash-command feature in `packages/runtime/src/preload/goal-feature.ts`. Product proof should exercise it through the real input box, not by unit-testing `parseGoalCommand` alone.
+
+Recommended CDP/Playwright flow:
+
+```sh
+node scripts/qa/cdp-slash-goal-smoke.mjs \
+  --endpoint http://127.0.0.1:9222 \
+  --out research/evidence/slash-goal/$(date +%Y%m%d-%H%M%S)
+```
+
+Flow:
+
+1. Attach to the real Codex target.
+2. Find the active prompt editable via accessibility role/text fallback.
+3. Type `/g`, assert the `/goal` suggestion renders.
+4. Press `Tab`, assert text expands to `/goal`.
+5. Type ` QA smoke objective <timestamp>` and press `Enter`.
+6. Assert a goal panel appears and `preload.log` records `goal set`.
+7. Type `/goal`, press `Enter`, assert current goal renders.
+8. Type `/goal clear`, press `Enter`, assert goal cleared notice renders.
+
+Evidence to save:
+
+- `before.png`
+- `suggestion.png`
+- `goal-set.png`
+- `goal-query.png`
+- `goal-cleared.png`
+- `preload-log-tail.txt`
+- `trace.zip` if using Playwright tracing
+- `result.json` with selector strategy used and timings
+
+Guardrail: the script must not send real model prompts. It should only interact with local slash-command handling and stop before a normal chat submit path when the command parser fails.
+
+### 1.5 Installer drift QA
+
+Installer drift means the installed app, runtime assets, watcher, and source package have stopped describing the same product. Codex++ has several drift surfaces:
+
+- `state.json` has `version`, `patchedAsarHash`, `codexVersion`, `codexChannel`, `watcher`.
+- `package.json` has repo version and scripts in the source checkout.
+- Runtime assets are copied into `packages/installer/assets/runtime` during build.
+- User runtime is staged under `~/Library/Application Support/codex-plusplus/runtime`.
+- Sparkle/update mode is tracked under `update-mode.json`.
+
+Recommended script:
+
+```sh
+scripts/qa/installer-drift.mjs \
+  --source /Users/af/codex-plusplus \
+  --user-root "$HOME/Library/Application Support/codex-plusplus" \
+  --app /Applications/Codex.app \
+  --out research/evidence/installer-drift.json
+```
+
+Exact probes:
+
+```sh
+node -e "console.log(JSON.stringify(require('$HOME/Library/Application Support/codex-plusplus/state.json'), null, 2))"
+node -e "console.log(JSON.stringify(require('$HOME/Library/Application Support/codex-plusplus/config.json'), null, 2))"
+diff -qr packages/runtime/dist packages/installer/assets/runtime
+diff -qr packages/installer/assets/runtime "$HOME/Library/Application Support/codex-plusplus/runtime"
+node packages/installer/dist/cli.js status
+node packages/installer/dist/cli.js doctor
+```
+
+Pass criteria:
+
+- Source version, installer state version, and runtime `CODEX_PLUSPLUS_VERSION` match unless a runtime update is intentionally pending.
+- `packages/runtime/dist` and `packages/installer/assets/runtime` match after build.
+- Installed user runtime matches `packages/installer/assets/runtime` after install/repair.
+- `update-mode.json` is absent or fresh and intentionally active.
+- Watcher command points at the installed CLI and does not depend on global npm.
+
+### 1.6 Visual proof bundle
+
+Every visible UI change needs route/state screenshots. For Codex++ this is less about routes and more about host states:
+
+- App launched, no settings open.
+- Settings open with Codex native settings restored.
+- Settings open with Codex++ Config selected.
+- Settings open with Tweaks selected.
+- Tweaks page with zero tweaks.
+- Tweaks page with one valid renderer tweak.
+- Tweak registered page visible in sidebar.
+- Tweak load failure visible in logs and not a broken UI.
+- Safe mode enabled.
+- Update available state.
+
+Recommended command:
+
+```sh
+node scripts/qa/cdp-visual-proof.mjs \
+  --endpoint http://127.0.0.1:9222 \
+  --matrix desktop=1440x1000,narrow=430x932 \
+  --out research/evidence/visual/$(date +%Y%m%d-%H%M%S)
+```
+
+Recommended proof manifest:
+
+```json
+{
+  "app": "/Applications/Codex.app",
+  "endpoint": "http://127.0.0.1:9222",
+  "viewports": ["1440x1000", "430x932"],
+  "screenshots": [
+    {
+      "name": "settings-codexpp-config-desktop.png",
+      "viewport": "1440x1000",
+      "assertions": ["Codex++ header visible", "auto-update toggle visible"]
+    }
+  ],
+  "logs": ["main-log-tail.txt", "preload-log-tail.txt"],
+  "result": "passed"
+}
+```
+
+Blank/false-positive checks:
+
+```sh
+sips -g pixelWidth -g pixelHeight research/evidence/visual/*/*.png
+```
+
+The script should also perform a simple pixel entropy check using `sharp` or `pngjs` so a white/transparent/black screenshot fails even if Playwright says capture succeeded.
+
+## 2. Medium Bets
+
+### 2.1 Add Playwright Test as the evidence runner
+
+Current repo tests use Node's built-in test runner through:
+
+```sh
+node --import tsx --test packages/*/test/*.test.ts
+```
+
+Keep that for pure package tests. Add Playwright Test only for product proof, artifact management, traces, screenshots, retries, and HTML/JSON reporting.
+
+Recommended dependency set, from current npm metadata checked on 2026-05-01:
+
+- `@playwright/test` 1.59.1, Apache-2.0, high-level browser automation and reporters.
+- `playwright-core` 1.59.1, Apache-2.0, enough when browsers are not installed because the target is existing Codex over CDP.
+- `chrome-remote-interface` 0.34.0, MIT, optional for raw CDP scripts that should not carry Playwright.
+- `pixelmatch` 7.2.0, ISC, small pixel-diff engine.
+- `pngjs` 7.0.0, MIT, pure JS PNG decode/encode for pixelmatch.
+- `sharp` 0.34.5, Apache-2.0, faster image processing and entropy/resize checks.
+
+Recommended first package addition:
+
+```sh
+npm install -D @playwright/test pixelmatch pngjs sharp
+```
+
+If keeping install weight low:
+
+```sh
+npm install -D playwright-core pixelmatch pngjs
+```
+
+Recommended config:
+
+```sh
+playwright.config.ts
+```
+
+Minimum settings:
+
+- `testDir: "testing/product-proof"`
+- `outputDir: "research/evidence/playwright-results"`
+- `reporter: [["list"], ["json", { outputFile: "research/evidence/playwright-results/results.json" }], ["html", { outputFolder: "research/evidence/playwright-report", open: "never" }]]`
+- `use.trace: "retain-on-failure"`
+- `use.screenshot: "only-on-failure"` for regular tests, explicit `page.screenshot()` for proof states.
+- `retries: 0` locally; retries can hide product-proof flakes.
+
+Commands:
+
+```sh
+npx playwright test --config playwright.config.ts
+npx playwright show-report research/evidence/playwright-report
+npx playwright show-trace research/evidence/playwright-results/<trace>.zip
+```
+
+### 2.2 Create a tiny fixture tweak pack
+
+Most visual states need known tweak data. Add a future fixture tweak pack under a test-only location, then link it with the existing CLI:
+
+```sh
+node packages/installer/dist/cli.js create-tweak testing/fixtures/tweaks/qa-renderer --id qa.renderer --name "QA Renderer" --repo agustif/codex-plusplus --scope renderer
+node packages/installer/dist/cli.js validate-tweak testing/fixtures/tweaks/qa-renderer
+node packages/installer/dist/cli.js dev testing/fixtures/tweaks/qa-renderer --name qa.renderer --replace --no-watch
+```
+
+Fixture tweak behaviors:
+
+- Register a small section on the Tweaks page.
+- Register a dedicated page with deterministic text and a button.
+- Log `qa renderer started`.
+- Write/read one storage value.
+- Expose one safe IPC round trip to a main fixture tweak.
+
+Do not depend on real user tweaks for product proof. Real tweak folders can contain private code and unstable UI.
+
+### 2.3 Add a patch sandbox for install/repair tests
+
+The current test suite has unit coverage for platform detection, tweak validation, update-mode, watcher health, storage, mcp sync, discovery, lifecycle, and git metadata. The missing middle is a disposable Electron-like app bundle fixture that can be patched end-to-end without touching `/Applications/Codex.app`.
+
+Recommended fixture generator:
+
+```sh
+scripts/qa/make-fake-codex-app.mjs --out /tmp/codexpp-fake/Codex.app
+```
+
+It should create:
+
+- `Contents/Info.plist`
+- `Contents/Resources/app.asar`
+- `Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework`
+- An asar with `package.json` and a tiny main entry.
+
+Recommended smoke:
+
+```sh
+npm run build
+node packages/installer/dist/cli.js install --app /tmp/codexpp-fake/Codex.app --no-resign --no-watcher --no-default-tweaks
+node packages/installer/dist/cli.js status
+node packages/installer/dist/cli.js doctor
+node packages/installer/dist/cli.js repair --app /tmp/codexpp-fake/Codex.app --force
+node packages/installer/dist/cli.js uninstall --app /tmp/codexpp-fake/Codex.app
+```
+
+This catches asar layout drift, loader injection failures, state mismatches, and uninstall restore issues without requiring a real Codex install.
+
+### 2.4 Add QA result normalization
+
+Recommended script:
+
+```sh
+scripts/qa/write-proof-summary.mjs --in research/evidence/<run> --out research/evidence/<run>/SUMMARY.md
+```
+
+The summary should contain:
+
+- App path.
+- Codex version and channel.
+- Codex++ source commit.
+- Dirty worktree summary.
+- Commands run.
+- Pass/fail table.
+- Screenshot list with viewport.
+- Log marker table.
+- Exact files attached or ready to attach to PR.
+
+This prevents "tested locally" PR bodies. The PR body can link or paste this summary.
+
+## 3. Wild Ideas Or Moonshots
+
+### 3.1 In-app QA tweak
+
+Build a test-only main+renderer tweak that exposes a local QA control panel inside Codex++ itself. It could request screenshots, dump target metadata, force reload tweaks, and render known states. This would be useful for manual dogfooding but should stay test-only and disabled by default.
+
+### 3.2 MCP proof server
+
+Codex++ already syncs tweak-provided MCP servers into `~/.codex/config.toml`. A dedicated QA MCP server could expose `codexpp_proof_run`, `codexpp_screenshot`, `codexpp_logs`, and `codexpp_installer_drift` tools for agents. That lets future agents generate product proof without remembering script flags.
+
+### 3.3 Visual history
+
+Store one screenshot manifest per release in `research/evidence/releases/<version>/`. The next release candidate can compare current screenshots against the previous release with `pixelmatch` and produce a diff bundle.
+
+This should not gate every PR at first. Use it for release candidates and large UI changes until baselines are stable.
+
+## 4. Constraints And Exact Evidence
+
+### 4.1 Current repo command caveat
+
+At exploration time, `/Users/af/codex-plusplus/package.json` in the working tree had drifted into a patched Codex app `package.json` with `name: "openai-codex-electron"` and `main: "codex-plusplus-loader.cjs"`. The committed root package still has the expected Codex++ workspace scripts.
+
+Use this to inspect the committed scripts without touching the dirty file:
+
+```sh
+git show HEAD:package.json | jq '.scripts'
+```
+
+Committed expected scripts:
+
+```sh
+npm run build
+npm test
+npm run audit
+```
+
+Direct package commands that avoid relying on root script discovery:
+
+```sh
+npm --prefix packages/sdk run build
+npm --prefix packages/runtime run build
+npm --prefix packages/installer run build
+node --import tsx --test packages/*/test/*.test.ts
+```
+
+Do not run any command that rewrites app bundles or root metadata in this dirty checkout until the package drift is intentionally resolved or moved into a clean worktree.
+
+### 4.2 Existing product surfaces found
+
+Runtime/product proof anchors:
+
+- Remote debug env in `packages/runtime/src/main.ts`: `CODEXPP_REMOTE_DEBUG=1`, `CODEXPP_REMOTE_DEBUG_PORT`.
+- Preload registration in `packages/runtime/src/main.ts`: prefers `session.registerPreloadScript`, falls back to `session.setPreloads`.
+- WebContents diagnostics in `packages/runtime/src/main.ts`: logs `web-contents-created` and `preload-error`.
+- Preload milestones in `packages/runtime/src/preload/index.ts`: `preload entry`, `react hook installed`, `settings injector started`, `tweak host started`, `manager mounted`, `boot complete`.
+- Settings DOM injection in `packages/runtime/src/preload/settings-injector.ts`.
+- Renderer tweak host and load-failure console/log behavior in `packages/runtime/src/preload/tweak-host.ts`.
+- Slash-command `/goal` flow in `packages/runtime/src/preload/goal-feature.ts`.
+- App-server bridge in `packages/runtime/src/preload/app-server-bridge.ts`.
+- Installer commands in `packages/installer/src/cli.ts`: `install`, `uninstall`, `repair`, `update-codex`, `update`, `status`, `doctor`, `create-tweak`, `validate-tweak`, `dev`, `safe-mode`.
+- Watcher install and update/repair scheduling in `packages/installer/src/watcher.ts`.
+- CI baseline in `.github/workflows/ci.yml`: `npm ci`, `npm test`, `npm run build`.
+
+### 4.3 Existing docs that should stay in sync
+
+- `README.md`: install, status, repair, update, update-codex, user paths.
+- `docs/ARCHITECTURE.md`: loader, runtime, preload, update handling.
+- `docs/TROUBLESHOOTING.md`: current manual DevTools/log guidance.
+- `docs/WRITING-TWEAKS.md`: tweak author diagnostics and API.
+
+The future QA scripts should update troubleshooting docs only after they exist. For this lane, the recommended scripts are documented here only.
+
+### 4.4 Security and safety boundaries
+
+- CDP port must be opt-in and local-only. Prefer `127.0.0.1` in scripts and never expose it on a public interface.
+- QA slash-command scripts must not send normal chat prompts if `/goal` parsing fails.
+- Evidence bundles must redact user paths when publishing outside the repo if they contain private home directory or tweak IDs.
+- Do not upload raw `preload.log`/`main.log` wholesale to public PRs. Tail and filter to Codex++ markers.
+- Fixture tweaks should be test-owned and deterministic. Do not run visual proof against arbitrary user tweak folders by default.
+- Installer smoke commands must default to a fake app bundle or explicit `--app` path. Never silently patch whichever Codex install is auto-detected in CI.
+
+## 5. Suggested Next Slice
+
+1. Recover or isolate the root package drift in a clean worktree before running root `npm` scripts.
+2. Add `scripts/qa/preload-log-smoke.mjs` first because it has no browser dependency and directly validates the existing log contract.
+3. Add `scripts/qa/cdp-proof.mjs` using Playwright over `CODEXPP_REMOTE_DEBUG_PORT=9222`.
+4. Add `testing/fixtures/tweaks/qa-renderer` and a main fixture only after the CDP proof can attach and capture screenshots.
+5. Add `scripts/qa/app-patch-smoke.mjs` and `scripts/qa/installer-drift.mjs`.
+6. Add Playwright Test config and move CDP proof flows into `testing/product-proof/*.spec.ts` once the script API is stable.
+7. Wire CI in two layers:
+   - Always: unit tests, build, fixture fake-app install/repair smoke.
+   - Manual macOS workflow: real Codex app patch proof, CDP screenshots, slash-command QA, and installer drift.
+
+Definition of done for the next implementation PR:
+
+- `node scripts/qa/preload-log-smoke.mjs --root "$HOME/Library/Application Support/codex-plusplus"` emits machine-readable JSON and non-zero exit on missing/failed markers.
+- `node scripts/qa/cdp-proof.mjs --endpoint http://127.0.0.1:9222 --out <dir>` captures at least one nonblank screenshot and target manifest.
+- PR body includes exact commands, evidence paths, and says whether visual proof was against fake app, real Codex stable, or real Codex beta.

--- a/research/agents/bundle-map.md
+++ b/research/agents/bundle-map.md
@@ -1,0 +1,127 @@
+# Codex Desktop Bundle And UI Surface Map
+
+Owner scope: recovered integration note for the read-only bundle/UI
+reverse-engineering lanes. Evidence came from the installed stable and beta
+Codex app bundles plus the agent reports returned in the thread.
+
+## 1. Evidence Baseline
+
+1. Stable app:
+   - Path: `/Applications/Codex.app`.
+   - Bundle id: `com.openai.codex`.
+   - Version: `26.429.20946`.
+   - Build: `2312`.
+   - Embedded CLI: `codex-cli 0.128.0-alpha.1`.
+
+2. Beta app:
+   - Path: `/Applications/Codex (Beta).app`.
+   - Bundle id: `com.openai.codex.beta`.
+   - Version: `26.429.21146`.
+   - Build: `2317`.
+   - Embedded CLI: `codex-cli 0.128.0-alpha.1`.
+
+3. Both bundles use the same Vite/asar shape, but chunk hashes differ. Any
+   integration that targets hashed chunk names must be treated as release-local
+   evidence, not a stable contract.
+
+## 2. Key Chunks
+
+Stable app chunks observed with `npx asar list`:
+
+- Composer: `/webview/assets/composer-B5UwBne4.js`.
+- Rich editor, sidebar, file tree, and model settings: `/webview/assets/use-model-settings-D_GIIENF.js`.
+- Thread header: `/webview/assets/thread-page-header-BE4NuQx7.js`.
+- Settings shell: `/webview/assets/settings-page-D8hwzVMU.js`.
+- Settings sections: `/webview/assets/settings-sections-0MrNUF6p.js`.
+- App-server manager hooks/signals: `/webview/assets/app-server-manager-hooks-DEjiw62x.js`, `/webview/assets/app-server-manager-signals-B_sRWyjv.js`.
+- Config and feature queries: `/webview/assets/config-queries-C-qINdQW.js`, `/webview/assets/experimental-features-queries-CNZ33-q_.js`.
+- MCP settings: `/webview/assets/mcp-settings-Cra-v5Bl.js`.
+- Worktree UI: `/webview/assets/worktree-DpJJHWcT.js`, `/webview/assets/worktrees-settings-page-nrR4SaaQ.js`.
+- Review UI: `/webview/assets/review-conversation-files-model-RS7Qf2Dn.js`, `/webview/assets/review-runtime-bridge-BmeBHgt2.js`.
+
+## 3. Best Immediate Wins
+
+1. Use Codex++ settings pages for admin/product surfaces.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+   - Reason: Settings has an existing Codex++ injection path. It avoids bundle
+     string patching and keeps product UI under a Codex++ owned root.
+
+2. Use a composer-anchored `/goal` overlay instead of native slash-menu
+   injection.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: medium-high.
+   - Dependency: Codex++ preload plus app-server protocol.
+   - Reason: the composer is ProseMirror, not a textarea. The native slash menu
+     is populated through private React hooks/signals in hashed chunks. A
+     Codex++ overlay can observe the editor and own its DOM.
+
+3. Use sidebar project/thread data attributes for read-only badges.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium-high.
+   - Dependency: Codex++ runtime seam.
+   - Useful selectors from the read-only pass:
+     - `[data-app-action-sidebar-scroll]`
+     - `[data-app-action-sidebar-section]`
+     - `[data-app-action-sidebar-project-row]`
+     - `[data-app-action-sidebar-thread-row]`
+   - Reason: these are better anchors than minified component names.
+
+4. Treat the file tree as a harder surface.
+   - Impact: high.
+   - Effort: medium-large.
+   - Confidence: medium.
+   - Dependency: native Codex seam plus Codex++ git metadata.
+   - Evidence: the file tree uses a virtualized custom/shadow surface with
+     `data-file-tree-virtualized="true"`.
+   - Recommendation: start with an outside-panel changed-files list and sidebar
+     header badges before mutating virtualized rows.
+
+## 4. Constraints And Exact Evidence
+
+1. The composer is ProseMirror.
+   - Stable selector from the read-only pass:
+     `.ProseMirror[data-codex-composer="true"][data-virtualkeyboard="true"]`.
+   - Do not set `.textContent` directly. Use passive reads, external UI, and
+     carefully scoped keyboard handling only while the Codex++ overlay is open.
+
+2. Native slash menu is not safely extensible today.
+   - The native command registry is private to minified React chunks.
+   - No public global, module registry, or app-server command-registration API
+     was found.
+   - Replacing or mutating native rows would be brittle across stable/beta.
+
+3. React fiber is an inspection aid, not an extension contract.
+   - Safe: read owner props for diagnostics, prefer stable DOM attributes, mount
+     Codex++ UI in its own root, and clean up observers/listeners.
+   - Unsafe: mutate fibers, refs, ProseMirror state, minified function state, or
+     native component props.
+
+4. Stable and beta differ by chunk hashes.
+   - Product features should avoid hard-coded chunk filenames. Keep chunk names
+     in research artifacts for local evidence only.
+
+## 5. Suggested Next Slice
+
+1. Keep `/goal` as a Codex++ command overlay:
+   - Observe the ProseMirror composer.
+   - Show a small suggestion when the current token is `/g`, `/go`, `/goal`, or
+     `/goal `.
+   - Complete on Tab/click and execute on exact `/goal` Enter.
+   - Yield when the native slash menu/dialog is visible.
+
+2. Build sidebar git awareness in layers:
+   - Project header branch/dirty/ahead-behind.
+   - Changed-files panel.
+   - File row badges only after shadow/virtualized row behavior is tested.
+
+3. Put support/admin tools in Settings first:
+   - Recovery Center.
+   - Observability page.
+   - Tweak Center.
+   - Project Snapshot page.
+

--- a/research/agents/easy-wins.md
+++ b/research/agents/easy-wins.md
@@ -1,0 +1,171 @@
+# Codex++ Easy Wins
+
+Scope: product-wise easy wins for Codex++ on the current local Codex Desktop shape. This note is ordered by what can ship fastest with the least dependence on brittle native Desktop internals.
+
+Current local baseline:
+
+- Codex.app is installed as `26.429.20946` (`plutil -p /Applications/Codex.app/Contents/Info.plist` showed `CFBundleShortVersionString => 26.429.20946`).
+- The repo research context says the embedded app-server is `codex-cli 0.128.0-alpha.1` and includes the `goals` feature flag. See `research/README.md:20-29`.
+- The product is still alpha; the README says installer needs real-device testing before declaring victory. See `README.md:7`.
+
+## Immediate Wins
+
+1. Ship a "Project Snapshot" page in Settings.
+   - Behavior: show current repo root, branch/head, dirty count, changed file count, insertions/deletions, ahead/behind, and linked worktrees.
+   - Why now: the metadata-only provider and tweak permission already exist. This is visible value without mutating repos or parsing raw diffs in the renderer.
+   - Product edge: Codex Desktop users routinely lose track of which worktree/thread they are in; a compact status card reduces wrong-branch and dirty-worktree mistakes.
+   - Effort: small to medium. Impact: high. Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+2. Ship `/goal` as a guarded Desktop command.
+   - Behavior: typing `/goal <objective>` in the composer creates or updates the thread goal, shows a small status panel, and lets the user pause, complete, or clear it.
+   - Why now: the preload feature already parses `/goal`, calls `thread/goal/*`, listens for goal notifications, and handles old app-server builds quietly.
+   - Product edge: Codex++ can make the hidden app-server goal primitive user-facing before Codex Desktop exposes it natively.
+   - Effort: small if the current in-flight implementation is stabilized and gated. Impact: high. Confidence: medium.
+   - Dependency: app-server protocol.
+
+3. Add a "Usage and Cost" page backed by the existing Codex session store.
+   - Behavior: daily/hourly tokens, model split, estimated API-equivalent cost, and current-thread burn when available.
+   - Why now: prior local evidence shows Codex Desktop writes to the shared `~/.codex/sessions/**/*.jsonl` store with `originator:"Codex Desktop"`. This can be implemented as read-only aggregation from main process with byte/time caps.
+   - Product edge: Codex Desktop still has weak feedback on spend and context burn; Codex++ can expose this without touching the app-server critical path.
+   - Effort: medium. Impact: high. Confidence: medium-high.
+   - Dependency: native Codex session files plus Codex++ runtime seam.
+
+4. Turn MCP-backed tweaks into a first-class install story.
+   - Behavior: a tweak can declare an MCP server, Codex++ syncs a managed block into `~/.codex/config.toml`, and Settings explains which tools were added.
+   - Why now: manifest support and managed MCP config sync already exist. The missing product layer is discoverability, validation, and in-app status.
+   - Product edge: Codex++ becomes a real extension system, not just DOM patches.
+   - Effort: small to medium. Impact: high. Confidence: high.
+   - Dependency: Codex++ runtime seam plus external tweak releases.
+
+5. Add an "Inspect Current Desktop" support panel.
+   - Behavior: show Codex version, Codex++ version, patch status, watcher health, preload status, app-server availability, and last loader/main/preload log lines.
+   - Why now: the repo already has watcher health, capped logs, config UI, and repair/status commands. Users need one screen to answer "is Codex++ actually loaded?"
+   - Product edge: this directly attacks the alpha support burden: patched Electron apps fail in opaque ways.
+   - Effort: small. Impact: medium-high. Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+6. Add a debug attach mode that is explicit, temporary, and visible.
+   - Behavior: Settings or CLI can restart Codex with `CODEXPP_REMOTE_DEBUG=1`, show the selected port, and display the `/json` attach URL.
+   - Why now: Codex production disables in-window DevTools, but Chromium remote debugging works via the command-line switch before app init.
+   - Product edge: gives maintainers and power users browser-grade diagnostics without requiring permanent devtools or source patching.
+   - Effort: small. Impact: medium. Confidence: high.
+   - Dependency: native Codex seam plus Codex++ runtime seam.
+
+7. Package a TypeScript tweak starter that actually bundles.
+   - Behavior: `codexplusplus create-tweak --template ts` produces a buildable tweak with SDK types, manifest validation, and one command to install/reload.
+   - Why now: the runtime does not transpile TypeScript and renderer tweaks must bundle dependencies. A starter removes the most common authoring trap.
+   - Product edge: increases tweak ecosystem throughput without widening runtime permissions.
+   - Effort: small. Impact: medium. Confidence: high.
+   - Dependency: Codex++ SDK/installer seam.
+
+8. Add stale-update and broken-update explanation to the in-app Config page.
+   - Behavior: if Sparkle or Codex++ self-update is in progress, explain whether the open window is still running old code and what restart/repair action is needed.
+   - Why now: release history already added update-mode status, watcher health, restart prompts, and safer Sparkle restoration.
+   - Product edge: prevents users from assuming a repair failed when only the currently open Electron process is stale.
+   - Effort: small. Impact: medium. Confidence: high.
+   - Dependency: Codex++ installer/runtime seam.
+
+9. Add a "safe defaults" permission review card for every tweak.
+   - Behavior: Settings lists declared permissions, entry existence, update source, MCP server declarations, and whether git/file APIs are available.
+   - Why now: permissions metadata, manifest validation, update checks, and MCP declarations exist, but the current manager still presents mostly name/version/load state.
+   - Product edge: builds trust around an extension system that evaluates local tweak code.
+   - Effort: small. Impact: medium. Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+10. Ship route-aware default tweak pages instead of only rows inside "Tweaks".
+    - Behavior: large tweaks can register dedicated Settings sidebar pages with icons and their own surfaces.
+    - Why now: the SDK already exposes `settings.registerPage`, and the injector already creates a tweak pages group.
+    - Product edge: lets Codex++ ship substantial features without cramming everything into one manager section.
+    - Effort: small. Impact: medium. Confidence: high.
+    - Dependency: Codex++ runtime seam.
+
+## Implementation Seams
+
+- Additive preload: runtime registers its preload with `session.setPreloads()` so Codex's own preload still runs. This is the safest default injection seam. Evidence: `docs/ARCHITECTURE.md:60-71`, `docs/ARCHITECTURE.md:95-97`.
+- Settings injection: current Desktop settings is a routed page with weak selectors, so injection must use DOM observation and text/content heuristics rather than stable test IDs. Evidence: `packages/runtime/src/preload/settings-injector.ts:1-21`, `packages/runtime/src/preload/settings-injector.ts:169-201`.
+- Renderer constraint: the renderer is sandboxed, cannot use Node fs, and cannot require arbitrary tweak files. Tweak source is fetched from main and evaluated in preload; dependencies must be bundled. Evidence: `packages/runtime/src/preload/tweak-host.ts:1-13`, `packages/runtime/src/preload/tweak-host.ts:104-130`.
+- Main-process tweak seam: main-scoped tweaks get disk storage, namespaced IPC, filesystem helpers, git metadata, and a native Codex API. Evidence: `packages/runtime/src/main.ts:647-667`.
+- Git metadata seam: main process owns bounded `git` subprocesses; renderer receives structured metadata only. Evidence: `docs/GIT_METADATA_SIDEBAR.md:23-49`, `packages/runtime/src/git-metadata.ts:154-249`.
+- App-server seam: preload can send `codex_desktop:message-from-view` MCP-shaped requests and subscribe to `codex_desktop:message-for-view` responses/notifications. Evidence: `packages/runtime/src/preload/app-server-bridge.ts:1-66`, `packages/runtime/src/preload/app-server-bridge.ts:86-174`.
+- Goal seam: `/goal` already maps composer text to `thread/goal/set`, `thread/goal/get`, update notifications, and status actions. Evidence: `packages/runtime/src/preload/goal-feature.ts:36-78`, `packages/runtime/src/preload/goal-feature.ts:187-231`, `packages/runtime/src/preload/goal-feature.ts:255-272`.
+- MCP seam: enabled tweaks can contribute managed MCP server entries without overwriting user-managed servers. Evidence: `packages/runtime/src/main.ts:680-698`, `packages/runtime/src/mcp-sync.ts:26-43`, `packages/runtime/src/mcp-sync.ts:47-80`.
+- Native window seam: main tweaks can ask Codex's window services to create registered BrowserViews/windows, but this depends on a minified-fingerprint patch staying valid. Evidence: `packages/installer/src/codex-window-services.ts:17-30`, `packages/runtime/src/main.ts:907-988`.
+- Update/repair seam: Codex updates overwrite the patch; watcher repair is expected to reapply it. Evidence: `docs/ARCHITECTURE.md:99-107`.
+- Debug seam: production Codex disables in-window DevTools, but Codex++ can enable Chromium remote debugging before app ready via env. Evidence: `packages/runtime/src/main.ts:53-67`.
+
+## Current Desktop Constraints
+
+- App bundle mutation is inherently fragile. Codex++ patches `app.asar`, updates Electron asar integrity metadata, flips the embedded asar fuse as a safety net, and ad-hoc re-signs the app. Evidence: `README.md:46-55`.
+- Official Codex updates conflict with a patched/ad-hoc signed app. The documented flow restores a Developer ID signed Codex.app before Sparkle updates, then relies on watcher repair. Evidence: `README.md:80-90`, `docs/ARCHITECTURE.md:99-113`.
+- Codex's renderer bundle is not a friendly extension target. The architecture notes say it is a Vite/Rollup single-entry build with no exposed module registry, so source string-patching is brittle. Evidence: `docs/ARCHITECTURE.md:87-89`.
+- Settings DOM can drift across Codex releases. The documented fallback is console warning and missing settings UI until heuristics are updated. Evidence: `docs/ARCHITECTURE.md:117-121`, `docs/TROUBLESHOOTING.md:40-45`.
+- Renderer code must assume sandboxing. Filesystem, git, and tweak source reads should remain main-process IPC services with timeouts and caps. Evidence: `packages/runtime/src/preload/index.ts:19-24`, `packages/runtime/src/preload/tweak-host.ts:248-258`.
+- App-server methods and feature flags are version-bound. `/goal` should degrade quietly on older builds and only show actionable errors after explicit user invocation. Evidence: `research/README.md:20-29`, `packages/runtime/src/preload/goal-feature.ts:226-230`.
+- Native window services are useful but less stable than Settings/preload/app-server seams because the installer has to fingerprint minified Desktop code. Evidence: `packages/installer/src/codex-window-services.ts:16-30`, `CHANGELOG.md:49-52`.
+
+## Effort / Impact / Confidence
+
+| Rank | Win | Effort | Impact | Confidence | Primary seam |
+|---:|---|---|---|---|---|
+| 1 | Project Snapshot page | small/medium | high | high | Git metadata API + settings page |
+| 2 | Guarded `/goal` command | small | high | medium | app-server protocol |
+| 3 | Usage and Cost page | medium | high | medium-high | session JSONL + main IPC |
+| 4 | MCP-backed tweak install/status | small/medium | high | high | manifest MCP sync |
+| 5 | Inspect Current Desktop panel | small | medium-high | high | status/log/watcher APIs |
+| 6 | Temporary debug attach mode | small | medium | high | env-gated remote debugging |
+| 7 | Buildable TS tweak starter | small | medium | high | installer + SDK |
+| 8 | Stale-update explanations | small | medium | high | watcher/update-mode state |
+| 9 | Permission review card | small | medium | high | manifest validation |
+| 10 | Dedicated tweak pages | small | medium | high | `settings.registerPage` |
+
+## Evidence Anchors
+
+- Product alpha and install mechanics: `README.md:5-15`, `README.md:46-58`, `README.md:147-168`.
+- Current repo research context: `research/README.md:20-29`.
+- Architecture boot path and constraints: `docs/ARCHITECTURE.md:47-75`, `docs/ARCHITECTURE.md:77-121`.
+- Tweak authoring and API surface: `docs/WRITING-TWEAKS.md:49-76`, `docs/WRITING-TWEAKS.md:128-144`, `docs/WRITING-TWEAKS.md:159-177`.
+- SDK permissions and settings pages: `packages/sdk/src/index.ts:64-83`, `packages/sdk/src/index.ts:300-341`.
+- Runtime preload and hot reload: `packages/runtime/src/preload/index.ts:1-17`, `packages/runtime/src/preload/index.ts:67-103`.
+- Renderer execution model: `packages/runtime/src/preload/tweak-host.ts:1-13`, `packages/runtime/src/preload/tweak-host.ts:104-130`, `packages/runtime/src/preload/tweak-host.ts:160-218`.
+- Git provider and plan: `packages/runtime/src/git-metadata.ts:154-249`, `docs/GIT_METADATA_SIDEBAR.md:23-111`.
+- App-server bridge and goal feature: `packages/runtime/src/preload/app-server-bridge.ts:29-66`, `packages/runtime/src/preload/app-server-bridge.ts:86-174`, `packages/runtime/src/preload/goal-feature.ts:36-78`.
+- MCP sync: `packages/runtime/src/mcp-sync.ts:26-43`, `packages/runtime/test/mcp-sync.test.ts:68-133`.
+- Existing test coverage for git metadata and lifecycle reload: `packages/runtime/test/git-metadata.test.ts:9-153`, `packages/runtime/test/main-toggle-reload.test.ts:24-98`.
+
+## Next 3 Shippable Slices
+
+1. Project Snapshot default page.
+   - Ship target: one built-in Codex++ page under Settings that renders repo status for a chosen/current project path.
+   - Scope:
+     - Use `api.git.getStatus`, `api.git.getDiffSummary`, and `api.git.getWorktrees`.
+     - Start with a stored path picker if current-thread project path extraction is not reliable yet.
+     - Render branch/head, dirty counts, changed files, insertions/deletions, and worktree list.
+     - Keep mutations out of scope.
+   - Acceptance:
+     - Works on clean repo, dirty repo, detached HEAD, non-repo path, and linked worktree.
+     - Uses existing metadata-only API; no raw file contents or diff hunks.
+     - Includes desktop/narrow screenshots because this is visible UI.
+
+2. Guarded `/goal` MVP.
+   - Ship target: `/goal` composer command plus status panel behind an explicit Codex++ config flag and feature detection.
+   - Scope:
+     - Keep current app-server calls to `thread/goal/set`, `thread/goal/get`, status update, and clear.
+     - Add one visible "unsupported on this Codex build" state only after the user types `/goal`.
+     - Avoid assuming every Desktop build has the `goals` flag.
+   - Acceptance:
+     - On current `26.429.20946` baseline, set/get/update/clear works against a real thread.
+     - On unsupported app-server response, the UI fails closed and does not spam panels on route changes.
+     - Include a short screen recording or screenshots of command suggestion, active goal, and complete/clear.
+
+3. Usage and Cost read-only panel.
+   - Ship target: a Codex++ Settings page that aggregates local session JSONL into daily/hourly usage and model-level estimates.
+   - Scope:
+     - Main process reads bounded chunks from `~/.codex/sessions/**/*.jsonl`.
+     - Renderer receives aggregate rows only.
+     - Price table must mark unknown pricing as unavailable rather than guessing.
+     - Start with local-only totals; thread-specific attribution can be a follow-up.
+   - Acceptance:
+     - Handles missing session dir, malformed lines, very large files, and unknown models.
+     - Shows partial/unavailable pricing explicitly.
+     - Cross-check one sample day against a known `clanker-stats --daily-stats --api-cost --by-model` run or equivalent local script.

--- a/research/agents/git-sidebar.md
+++ b/research/agents/git-sidebar.md
@@ -1,0 +1,207 @@
+# Git Metadata In Sidebar Surfaces
+
+## 1. Best Immediate Wins
+
+1. Project/sidebar repository header.
+   - Product: show the active branch or detached short SHA beside the project name, then compact `+ahead/-behind`, dirty count, and current worktree root.
+   - Why: the current project surface can tell the user where they are before they ask an agent to edit. This prevents wrong-branch and wrong-worktree mistakes.
+   - Evidence: `docs/GIT_METADATA_SIDEBAR.md` says the runtime already exposes repository resolution, branch, upstream, ahead, behind, detached state, root, git dir, common dir, bare state, and worktree state. `packages/runtime/src/git-metadata.ts` returns `GitStatus.branch` with `head`, `upstream`, `ahead`, and `behind`, plus `GitRepositoryResolution.root`, `headBranch`, and `headSha`.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+2. File/project sidebar badges for path state.
+   - Product: add tiny fixed-width badges in file rows: `S` for staged/index changes, `M` for worktree changes, `U` for untracked, `R` for rename, conflict marker for unmerged, and binary marker when diff summary marks a path binary.
+   - Why: agents and humans both need to see whether a file is dirty before opening or editing it. The key value is not full diff rendering; it is cheap ambient awareness.
+   - Evidence: the docs name these exact first-pass badges. `GitStatusEntry` separates ordinary, rename, unmerged, untracked, and ignored entries; ordinary and rename entries preserve `index` and `worktree` status columns from porcelain v2. `GitDiffFileSummary` carries `binary`, `oldPath`, insertions, and deletions.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+3. Dirty-files section scoped to visible project paths.
+   - Product: a collapsible "Changed files" cluster in the project sidebar, ordered by conflict, staged, unstaged, untracked, renamed, ignored. Include count chips and keep ignored hidden behind an explicit toggle.
+   - Why: a sidebar file tree should not require a terminal status check for basic situational awareness. This is also the safest first UX because it is read-only.
+   - Evidence: `getStatus(path)` already returns all entries from `git status --porcelain=v2 -z --branch --untracked-files=all`; ignored entries are parsed as `kind: "ignored"` if present. The runtime doc says metadata is read-only and does not scan the filesystem from the renderer.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+4. Diff footer for project health at a glance.
+   - Product: show `N files`, `+insertions`, `-deletions`, and a `truncated` warning in the sidebar footer or project header hovercard.
+   - Why: this gives enough size signal to decide whether to review now, split work, or ask an agent to summarize before continuing.
+   - Evidence: `getDiffSummary(path)` returns `fileCount`, `insertions`, `deletions`, per-file summaries, and `truncated`. The provider uses `git diff --numstat -z --find-renames --find-copies HEAD --` when `HEAD` exists and cached diff in initial-commit repos.
+   - Impact: medium.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+5. Worktree switcher and collision warning.
+   - Product: if more than one linked worktree exists, expose a worktree popover with branch/head/path rows and warning states for locked or prunable worktrees. Mark the current root clearly.
+   - Why: this directly supports parallel agent work. It also catches the common "same branch checked out elsewhere" or "stale prunable worktree" problem before edits start.
+   - Evidence: `getWorktrees(path)` parses `git worktree list --porcelain -z` into `path`, `head`, `branch`, `detached`, `bare`, `locked`, `lockedReason`, `prunable`, and `prunableReason`. The sidebar doc already calls out linked worktree display and locked/prunable marking.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+6. Read-only review mode entrypoint.
+   - Product: add a "Review changes" command from the sidebar that opens a review panel seeded with current dirty files and diff summary. Initial version can be metadata-only: counts, path list, staged/unstaged/conflict grouping, and "ask agent to review" handoff.
+   - Why: the runtime deliberately avoids raw hunks today, but the product can still create a strong review doorway without adding mutating git operations.
+   - Evidence: docs say the app-server thread model exposes coarse `gitInfo` and `gitDiffToRemote`, while Codex++ exposes richer per-file status and diff summary. `docs/WRITING-TWEAKS.md` says `api.git` intentionally does not return raw diff hunks or file contents.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: Codex++ runtime seam plus native Codex UI seam.
+
+## 2. Medium Bets
+
+1. PR context chip in the repository header.
+   - Product: when upstream branch or remote URL maps to GitHub, show PR number/title/status if discoverable, with a fallback to "No PR context". Keep this separate from the read-only git metadata provider.
+   - Why: branch and dirty state are local; reviewers also need to know whether the current branch already has an open PR, failing checks, unresolved reviews, or merge conflicts.
+   - Evidence: current runtime git API has local branch/upstream/head/worktree data only. No API currently returns GitHub PR metadata, checks, reviews, labels, or mergeability. `docs/ARCHITECTURE.md` shows the runtime already has advisory GitHub release metadata fetching for tweak updates, but that is not repo PR context.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: external service.
+
+2. Workspace health strip.
+   - Product: a compact health line: repo found/not found, branch state, dirty count, conflict count, truncated status, worktree count, upstream ahead/behind, and stale metadata age.
+   - Why: this converts raw git facts into an operational "safe to work?" signal for agents and users.
+   - Evidence: the provider already returns structured errors for not-a-repository, timeout, spawn-error, and git-failed; it also returns `truncated`, `clean`, and worktree metadata. It does not yet return refresh timestamps, so the UI should own `lastFetchedAt`.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+3. Conflict-first mode.
+   - Product: when any `unmerged` entry exists, promote conflicts above the normal file tree and expose "open conflicted files", "ask agent to resolve", and "show conflict count" actions.
+   - Why: conflicts are qualitatively different from ordinary dirty state. They should interrupt review mode and workspace health.
+   - Evidence: porcelain v2 `u` entries are parsed into `GitUnmergedStatusEntry` with `index`, `worktree`, `submodule`, and `path`. There is no hunk-level conflict API, so the first version should navigate and triage, not attempt resolution from the sidebar.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam plus native Codex file navigation seam.
+
+4. Staged vs unstaged review grouping.
+   - Product: show separate groups for staged/index changes, unstaged/worktree changes, and untracked files. For a file with both staged and unstaged changes, show a split badge such as `S+M`.
+   - Why: staged files indicate user intent; unstaged files indicate active work. Agents should not blur them.
+   - Evidence: ordinary and rename status entries carry both `index` and `worktree` columns. The current diff summary is aggregate against `HEAD`, so per-file staged-vs-unstaged line counts would require a later API addition.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+
+5. Branch-to-remote review summary.
+   - Product: show "local changes" separately from "branch review delta" once branch comparison to upstream/remote is available. Use this for PR review mode and "what will reviewers see?".
+   - Why: local dirty files and committed branch delta are different decisions. The sidebar should not make users infer PR scope from working-tree scope.
+   - Evidence: `docs/GIT_METADATA_SIDEBAR.md` says upstream Codex has review summaries and branch-to-remote comparison, while app-server `gitDiffToRemote` is coarse. The Codex++ provider currently exposes ahead/behind but not committed-file diff to upstream.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: native Codex seam or expanded Codex++ runtime seam.
+
+6. Safe "handoff to agent" context package.
+   - Product: from a file/project/sidebar action, package branch, head SHA, root, dirty entries, diff summary, worktree list, and truncation flags into a structured prompt attachment for a new agent.
+   - Why: it gives agents exact git state without dumping raw diffs or credentials into chat. It also aligns with the runtime's metadata-only contract.
+   - Evidence: `api.git` already returns JSON-like metadata over IPC, and `docs/WRITING-TWEAKS.md` explicitly says it does not expose raw diff hunks, file contents, remote credentials, or ignored file trees by default.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: Codex++ runtime seam plus native Codex composer/thread seam.
+
+## 3. Wild Ideas Or Moonshots
+
+1. Multi-worktree mission control.
+   - Product: a sidebar workspace map where each worktree is a lane with branch, head, PR, dirty/conflict state, assigned agent, last command, and health.
+   - Why: Codex++ can become the orchestrator surface for parallel agent branches rather than only a tweak runtime.
+   - Evidence: current `getWorktrees` gives enough local topology to start. Agent assignment, last command, and PR state are not in the git provider.
+   - Impact: moonshot.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: Codex++ runtime seam plus external service plus agent/task state.
+
+2. Review heatmap over the file tree.
+   - Product: shade files by diff size, churn, binary status, and conflict risk; fold generated or ignored paths by default.
+   - Why: reviewers and agents need to spend attention where the change is largest or riskiest.
+   - Evidence: `getDiffSummary` has per-file insertions/deletions/binary/rename data but not hunk-level semantics, ownership, generated-file detection, or language parser output.
+   - Impact: high.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: Codex++ runtime seam plus optional local analysis.
+
+3. PR readiness gate.
+   - Product: a "ready to PR?" panel that checks dirty state, staged leakage, conflicts, branch sync, tests last run, review status, CI, and screenshot evidence for visual changes.
+   - Why: this turns sidebar git metadata into a release/review workflow.
+   - Evidence: local git state is available; test history, screenshot evidence, CI, and review threads are not currently part of this provider.
+   - Impact: high.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: external service plus repo-local validation artifacts.
+
+4. Conflict-resolution cockpit.
+   - Product: when conflicts are detected, open a guided side-by-side flow with file navigation, base/ours/theirs summaries, agent suggestions, and post-resolution status checks.
+   - Why: conflict resolution is a high-friction task where agents can help, but only if the UI keeps exact state visible.
+   - Evidence: current API can detect unmerged paths only. It does not expose stages, blob contents, conflict hunks, merge base, or resolution commands.
+   - Impact: moonshot.
+   - Effort: large.
+   - Confidence: low.
+   - Dependency: expanded Codex++ runtime seam.
+
+## 4. Constraints And Exact Evidence
+
+1. Renderer access is permission-gated.
+   - Evidence: `docs/WRITING-TWEAKS.md` requires `"permissions": ["git.metadata"]`; `packages/runtime/src/preload/tweak-host.ts` only attaches `api.git` when the manifest includes `git.metadata`; `packages/sdk/src/index.ts` validates `git.metadata` as a known permission.
+   - Product constraint: every sidebar tweak that reads git metadata needs a manifest update and a no-permission empty state.
+
+2. The provider is metadata-only and read-only.
+   - Evidence: docs say it does not return raw diff hunks, file contents, remote credentials, or ignored file trees by default. The runtime API only includes `resolveRepository`, `getStatus`, `getDiffSummary`, and `getWorktrees`.
+   - Product constraint: first sidebar versions should not promise commit, stage, checkout, merge, fetch, or conflict-resolution actions.
+
+3. Main process owns git subprocesses.
+   - Evidence: `packages/runtime/src/git-metadata.ts` uses `spawn(config.gitPath, args, { shell: false })`, bounded stdout/stderr byte caps, and a timeout. Preload exposes IPC handlers `codexpp:git-status`, `codexpp:git-diff-summary`, and `codexpp:git-worktrees`.
+   - Product constraint: renderer code should request structured metadata and cache/debounce it; it should not shell out.
+
+4. Large repos and truncated output are first-class states.
+   - Evidence: default caps are `1 MiB` stdout and `64 KiB` stderr; status and diff summary return `truncated`.
+   - Product constraint: show "partial" or "truncated" state instead of silently presenting incomplete counts as definitive.
+
+5. Initial commits, detached HEAD, bare repositories, and non-repositories need explicit states.
+   - Evidence: `resolveRepository` can return `found: false`, `isBare`, `isInsideWorkTree`, null root/head branch/head SHA. `getDiffSummary` falls back to cached diff when `headSha` is missing.
+   - Product constraint: no repo should hide git UI, bare repo should not show working-tree file badges, initial commit should avoid branch-to-HEAD assumptions, detached HEAD should show short SHA.
+
+6. Current diff summary is against `HEAD`, not split by index/worktree.
+   - Evidence: `getDiffSummary` uses `git diff --numstat ... HEAD --` when `HEAD` exists and cached diff only when no `HEAD` exists.
+   - Product constraint: `S` and `M` badges can come from status entries, but staged-vs-unstaged insertion/deletion counts require a future API.
+
+7. Current PR context is not available in the git provider.
+   - Evidence: runtime git types have no PR, check, review, mergeability, issue, or remote-host API. GitHub usage in the runtime is currently release metadata for tweaks, not project PR state.
+   - Product constraint: PR chips should be a second data source with clear loading, auth, and offline states.
+
+## 5. Suggested Next Slice
+
+1. Build a read-only `useGitMetadata(rootPath)` hook in the sidebar tweak layer.
+   - Fetch `getStatus`, `getDiffSummary`, and `getWorktrees` in parallel.
+   - Cache by repository root.
+   - Refresh on sidebar open, focus regain, route/project change, and after known file-writing tool events if that seam is available.
+   - Debounce per root and show stale age.
+
+2. Render the smallest useful UI first.
+   - Header: branch or short SHA, dirty count, ahead/behind, current worktree.
+   - File rows: `S`, `M`, `U`, `R`, conflict, binary badges.
+   - Footer: file count, insertions, deletions, truncated warning.
+
+3. Add worktree and review affordances after screenshots prove the basics.
+   - Worktree popover with path, branch/head, locked/prunable flags.
+   - Metadata-only "Review changes" panel grouped by conflict, staged, unstaged, untracked, renamed, binary.
+
+4. Defer mutating operations.
+   - No stage/unstage, checkout, branch creation, fetch, merge, rebase, conflict resolution, or PR writes until the read-only model proves stable.
+
+5. Future API extensions worth considering.
+   - `getDiffSummary(path, { base: "HEAD" | "index" | "worktree" | "upstream" })` for staged/unstaged and branch-to-remote grouping.
+   - `getRemoteInfo(path)` returning sanitized remote host/owner/repo/default branch without credentials.
+   - `getConflictSummary(path)` returning unmerged stage metadata without file contents.
+   - `watchGitMetadata(root)` or event hooks so the UI can avoid slow polling.

--- a/research/agents/goal-workflows.md
+++ b/research/agents/goal-workflows.md
@@ -1,0 +1,440 @@
+# Goal Workflows Product Notes
+
+Scope: explore product possibilities around Codex `/goal` for Codex++ without changing runtime code. Ordered from shippable UX wins to protocol-level bets.
+
+## 1. Best Immediate Wins
+
+### 1. Goal Pill In The Thread Chrome
+
+- Impact: high
+- Effort: medium
+- Confidence: high
+- Dependency: Codex++ runtime seam + app-server protocol
+
+Replace the current floating goal panel with a persistent, compact goal pill near the thread header or composer. The pill should show status, objective truncation, token usage, and elapsed time. Click opens the existing actions: Pause, Resume, Complete, Clear.
+
+Why this should be first:
+
+- The server already exposes the state needed for a pill: objective, status, tokenBudget, tokensUsed, timeUsedSeconds, createdAt, and updatedAt.
+- The current UI already renders these fields, but as a bottom-right panel that can feel like a toast instead of durable thread state.
+- A pill gives users continuous orientation without forcing them to run `/goal` repeatedly.
+
+Evidence:
+
+- Native generated `ThreadGoal` has `threadId`, `objective`, `status`, `tokenBudget`, `tokensUsed`, `timeUsedSeconds`, `createdAt`, and `updatedAt` from `codex app-server generate-ts --experimental --out <tmp>`.
+- Codex++ mirrors that shape locally in `packages/runtime/src/preload/goal-feature.ts:3-14`.
+- Current rendering already formats status, budget, and elapsed time in `packages/runtime/src/preload/goal-feature.ts:255-272`.
+- Current panel is fixed at bottom-right with max z-index in `packages/runtime/src/preload/goal-feature.ts:470-590`, which is useful for a prototype but not a native-feeling thread affordance.
+
+Implementation notes:
+
+- Keep the current panel as the popover content.
+- Move persistent display into a pill mounted near a stable route/thread container after DOM reconnaissance.
+- Use the existing notification listener and route refresh path first; do not add a second state source for v1.
+- Mobile/narrow layout must collapse to a status dot plus short objective.
+
+### 2. Make `/goal` A Real Command Surface
+
+- Impact: high
+- Effort: small
+- Confidence: high
+- Dependency: Codex++ runtime seam + app-server protocol
+
+Current grammar supports `/goal`, `/goal clear`, `/goal pause`, `/goal resume`, `/goal complete`, and `/goal <objective>`. Expand it to:
+
+- `/goal set <objective>`
+- `/goal budget 50000`
+- `/goal budget none`
+- `/goal status`
+- `/goal done`
+- `/goal clear`
+
+Why this matters:
+
+- `tokenBudget` is already in the protocol but currently not exposed by Codex++ commands.
+- Users need predictable subcommands once `/goal` grows beyond a novelty.
+- Aliases like `done` should map to `complete` because completion is a high-frequency action.
+
+Evidence:
+
+- Existing parser treats any non-keyword argument as a replacement objective in `packages/runtime/src/preload/goal-feature.ts:121-195`.
+- Native generated `ThreadGoalSetParams` accepts optional `objective`, `status`, and `tokenBudget` from `codex app-server generate-ts --experimental --out <tmp>`.
+- Status values are exactly `active`, `paused`, `budgetLimited`, and `complete` from generated `ThreadGoalStatus`.
+- The `/goal` composer suggestion is already installed in `packages/runtime/src/preload/goal-feature.ts:397-453`.
+
+Implementation notes:
+
+- Parse explicitly before falling back to objective replacement.
+- Keep backwards compatibility for `/goal <objective>`.
+- Render validation errors in the existing panel path.
+- Add tests for command parsing before touching DOM-heavy code.
+
+### 3. Completion Reporting
+
+- Impact: high
+- Effort: small
+- Confidence: high
+- Dependency: app-server protocol
+
+When a goal is marked complete, show a completion report instead of only re-rendering the goal state:
+
+- objective
+- final status
+- elapsed time
+- tokens used
+- budget delta when tokenBudget is set
+- copyable handoff text
+
+Why this matters:
+
+- Completion is the moment where the product can turn work into an auditable outcome.
+- The data already exists in `ThreadGoal`; the missing piece is a focused report view.
+
+Evidence:
+
+- Current `complete` action calls `thread/goal/set` with status `complete` in `packages/runtime/src/preload/goal-feature.ts:165-174` and `packages/runtime/src/preload/goal-feature.ts:344-353`.
+- `ThreadGoalUpdatedNotification` includes `turnId: string | null` in generated app-server bindings, which can later tie completion to the turn that changed state.
+- Existing render path already formats token/time fields in `packages/runtime/src/preload/goal-feature.ts:255-263`.
+
+Implementation notes:
+
+- On status transition to `complete`, render a report variant with Copy Summary, Clear, and Resume.
+- Keep report text local and deterministic; do not ask the model to summarize in v1.
+- Later, attach changed files/checks if a git metadata sidebar lands.
+
+### 4. Budget UX And Budget-Limited State
+
+- Impact: high
+- Effort: medium
+- Confidence: medium
+- Dependency: app-server protocol
+
+Expose budget as a first-class goal control:
+
+- set token budget when creating a goal
+- edit budget from the pill menu
+- show remaining tokens and percent used
+- render `budgetLimited` as a blocking or warning state
+
+Evidence:
+
+- `ThreadGoal` includes `tokenBudget` and `tokensUsed`; current UI displays either `used tokens` or `used / budget tokens` in `packages/runtime/src/preload/goal-feature.ts:255-263`.
+- The app-server status enum includes `budgetLimited`; Codex++ already labels it as `limited by budget` in `packages/runtime/src/preload/goal-feature.ts:694-704`.
+- `ThreadGoalSetParams` includes `tokenBudget?: number | null` from generated app-server bindings.
+
+Unknowns:
+
+- I did not prove whether the app-server itself enforces tokenBudget or only stores it.
+- I did not prove whether `budgetLimited` is set automatically by native runtime accounting or only by explicit status mutation.
+
+Implementation notes:
+
+- Treat budget as advisory until native enforcement is proven.
+- Do not block user input purely in Codex++ v1; visually warn and offer Complete, Resume, or Increase Budget.
+- Add app-server smoke tests before claiming native budget enforcement.
+
+### 5. Feature Detection And Error States
+
+- Impact: medium
+- Effort: small
+- Confidence: high
+- Dependency: app-server protocol
+
+Make the goal affordance self-gating:
+
+- hide passive goal UI when app-server support is missing
+- show a precise setup action when `goals` is disabled
+- report experimentalApi negotiation errors separately
+
+Evidence:
+
+- Local config currently has `[features].goals = true` at `/Users/af/.codex/config.toml:38-47`.
+- `codex features list` reports `goals under development true`.
+- `codex --help` has no top-level `goal` command; this is an app-server/TUI feature, not a standalone CLI workflow.
+- Existing Codex++ error mapper already distinguishes disabled goals, missing `experimentalApi`, and unsupported `thread/goal/*` in `packages/runtime/src/preload/goal-feature.ts:707-718`.
+- Route refresh intentionally stays quiet on unsupported old app-server builds in `packages/runtime/src/preload/goal-feature.ts:206-230`.
+
+Implementation notes:
+
+- Add a cached `goalFeatureAvailable` state after first successful `thread/goal/get`.
+- Do not spam app-server every 2.5s after a definitive unsupported error.
+- Keep manual `/goal` attempts noisy and actionable.
+
+## 2. Medium Bets
+
+### 1. Thread Goal History
+
+- Impact: high
+- Effort: medium
+- Confidence: medium
+- Dependency: Codex++ runtime seam first, app-server protocol later
+
+Build local thread goal history as an append-only Codex++ journal:
+
+- created
+- objective changed
+- budget changed
+- paused/resumed
+- completed
+- cleared
+
+Why this is a Codex++ layer first:
+
+- The generated app-server protocol exposes get, set, clear, updated notification, and cleared notification.
+- It does not expose a goal history/list endpoint.
+- Codex++ can record event history from notifications without requiring upstream changes.
+
+Evidence:
+
+- Current Codex++ listens for `thread/goal/updated` and `thread/goal/cleared` in `packages/runtime/src/preload/goal-feature.ts:53-70`.
+- Generated `ThreadGoalUpdatedNotification` has `threadId`, `turnId`, and `goal`.
+- Generated `ThreadGoalClearedNotification` has `threadId`.
+- The bridge can receive notifications independent of request/response matching in `packages/runtime/src/preload/app-server-bridge.ts:94-118` and `packages/runtime/src/preload/app-server-bridge.ts:155-173`.
+
+Implementation notes:
+
+- Store only metadata by default: threadId, event type, timestamps, goal fields, and optional turnId.
+- Do not store raw chat content.
+- Reconcile on startup by calling `thread/goal/get` for the current thread and appending a synthetic snapshot only if the local journal has no current state.
+- Later app-server ask: `thread/goal/history/list`.
+
+### 2. Goal Templates
+
+- Impact: medium
+- Effort: medium
+- Confidence: medium
+- Dependency: Codex++ runtime seam
+
+Add reusable templates for common work:
+
+- "Fix CI on current PR"
+- "Implement feature with tests"
+- "Review pending PR"
+- "Visual QA route"
+- "Write research artifact"
+- "Prepare handoff summary"
+
+Template fields:
+
+- objective text with variables
+- default token budget
+- optional reminder cadence
+- completion report format
+
+Evidence:
+
+- Research scoring already expects ideas to carry Impact, Effort, Confidence, and Dependency in `research/README.md:11-18`.
+- Codex++ tweak storage exists as a renderer API in `packages/runtime/src/preload/tweak-host.ts:1-20` and the broader runtime stores user preferences under `<user-data-dir>/config.json` per `docs/ARCHITECTURE.md:20-34`.
+- `/goal` creation only needs `threadId`, `objective`, `status`, and optionally `tokenBudget`, so templates can stay client-side until the app-server has native support.
+
+Implementation notes:
+
+- Start with local JSON templates in Codex++ config or tweak-data.
+- Offer template selection from the `/goal` suggestion popover once the user types `/goal `.
+- Keep templates editable from Settings later, not in the first pill slice.
+
+### 3. Goal Reminders
+
+- Impact: medium
+- Effort: medium
+- Confidence: medium
+- Dependency: Codex++ runtime seam
+
+Add opt-in local reminders:
+
+- "No progress for 15 minutes"
+- "Budget 80% used"
+- "Goal active across route/thread switch"
+- "Goal still active at close/quit"
+
+Evidence:
+
+- Current feature already refreshes route state on popstate and every 2.5s in `packages/runtime/src/preload/goal-feature.ts:72-77`.
+- App-server notifications can drive event-first updates through `onAppServerNotification` in `packages/runtime/src/preload/app-server-bridge.ts:68-74`.
+- Token and time values are available on every `ThreadGoal`.
+
+Implementation notes:
+
+- Keep reminders local and dismissible.
+- Do not fire reminders while a turn is actively producing output unless native turn status is wired in.
+- Use notification-driven state first, then poll as a fallback.
+- Later app-server ask: goal dueAt/reminderAt fields, but avoid inventing them before proving local UX.
+
+### 4. Goal-Aware Thread List And Recents
+
+- Impact: medium
+- Effort: large
+- Confidence: low
+- Dependency: native Codex seam + app-server protocol
+
+Show active goals outside the current thread:
+
+- sidebar/recents badge for active or budget-limited goals
+- filter "threads with active goals"
+- resume unfinished goal thread
+
+Constraint:
+
+- The current generated protocol proves per-thread get/set/clear, but not a cross-thread goal list.
+- Codex++ can only know other thread goals if it has observed them or if it can enumerate threads and call `thread/goal/get` per thread without causing load.
+
+Implementation notes:
+
+- Do not start by polling all threads.
+- First, show badges only for threads seen in the local Codex++ journal.
+- Later app-server ask: `thread/goal/list` with status filters and lightweight pagination.
+
+## 3. Wild Ideas Or Moonshots
+
+### 1. Multi-Goal DAGs And Epics
+
+- Impact: moonshot
+- Effort: large
+- Confidence: low
+- Dependency: external service or new app-server protocol
+
+Build a small goal graph above native single-goal threads:
+
+- parent epic
+- child goals per thread/subagent
+- dependencies
+- acceptance checks
+- completion artifacts
+
+Why this is not v1:
+
+- Native `ThreadGoalGetResponse` returns one goal or null.
+- Native `ThreadGoalSetParams` sets one objective/status/budget for one thread.
+- Multi-goal DAGs would be a Codex++ product layer, not a thin `/goal` UI.
+
+### 2. Goal-Aware Work Reports
+
+- Impact: high
+- Effort: large
+- Confidence: medium
+- Dependency: Codex++ runtime seam + git metadata + optional external service
+
+Use completion reports as structured work proof:
+
+- goal objective
+- completion status
+- changed files
+- commands run
+- screenshots or visual proof
+- PR body draft
+
+Evidence:
+
+- The git metadata plan notes that app-server thread git data is coarse, while Codex++ has a richer main-process git provider available behind `git.metadata` permission in `docs/GIT_METADATA_SIDEBAR.md:18-36`.
+- A completion report already has core time/token fields from `ThreadGoal`.
+
+Implementation notes:
+
+- Do not block the first `/goal` work on git integration.
+- Add "Attach evidence" after completion reporting is proven.
+
+### 3. Goal Templates From Repo Context
+
+- Impact: medium
+- Effort: large
+- Confidence: low
+- Dependency: native Codex seam + Codex++ runtime seam
+
+Generate goal templates from repo shape:
+
+- AGENTS.md instructions
+- Justfile/package scripts
+- current branch and PR
+- failing checks
+- dirty files
+
+This should be explicit user action, not automatic prompt stuffing. The safe version proposes templates; it does not silently modify the current goal.
+
+## 4. Constraints And Exact Evidence
+
+### Protocol Constraints
+
+1. The goal protocol is thread-scoped and single-goal shaped.
+   - Generated `ThreadGoalGetParams`: `{ threadId: string }`.
+   - Generated `ThreadGoalGetResponse`: `{ goal: ThreadGoal | null }`.
+   - Generated `ThreadGoalSetParams`: `{ threadId: string, objective?: string | null, status?: ThreadGoalStatus | null, tokenBudget?: number | null }`.
+   - Generated `ThreadGoalClearResponse`: `{ cleared: boolean }`.
+
+2. The only proven statuses are:
+   - `active`
+   - `paused`
+   - `budgetLimited`
+   - `complete`
+
+3. The only proven goal notifications are:
+   - `thread/goal/updated`
+   - `thread/goal/cleared`
+
+4. History, templates, reminders, due dates, multi-goal lists, and cross-thread goal querying are not proven native protocol features.
+
+### Codex++ Runtime Constraints
+
+1. The goal feature is a preload-level DOM shim, not native React source.
+   - `startGoalFeature` is called before normal boot in `packages/runtime/src/preload/index.ts:53-57`.
+   - The architecture prefers preload/DOM observation because Codex's renderer bundle is brittle to source patching in `docs/ARCHITECTURE.md:87-89`.
+
+2. The app-server bridge is request/response over Codex desktop IPC.
+   - Requests use `codex_desktop:message-from-view`, `type: "mcp-request"`, `hostId`, and `{ id, method, params }` in `packages/runtime/src/preload/app-server-bridge.ts:29-66`.
+   - Notifications arrive through `codex_desktop:message-for-view` and are decoded separately from responses in `packages/runtime/src/preload/app-server-bridge.ts:86-118`.
+   - Default request timeout is 12 seconds in `packages/runtime/src/preload/app-server-bridge.ts:3-5`.
+
+3. Thread id extraction is route-derived and local-thread-biased.
+   - `readThreadId` searches location, hash, href, initialRoute, and history state for `/local/<id>` in `packages/runtime/src/preload/goal-feature.ts:656-670`.
+   - This means remote or future non-local route shapes need explicit validation before goal UI is claimed supported.
+
+4. Current polling only refreshes on route/thread changes.
+   - `refreshGoalForRoute` returns early when `threadId === lastThreadId` in `packages/runtime/src/preload/goal-feature.ts:206-230`.
+   - Live updates depend on notifications, not repeated same-thread polling.
+
+5. Renderer filesystem access is constrained.
+   - The preload notes that sandboxed renderer cannot `require("node:fs")`; logs are forwarded to main via IPC in `packages/runtime/src/preload/index.ts:19-33`.
+   - Any local goal history store should use main-process storage or existing tweak storage rather than renderer filesystem writes.
+
+### Environment Evidence
+
+1. Repo context says Codex Desktop `26.429.20946`, embedded `codex-cli 0.128.0-alpha.1`, and goals flag are present in `research/README.md:20-29`.
+2. Installed CLI is `codex-cli 0.128.0`.
+3. `codex features list` reports `goals under development true`.
+4. `/Users/af/.codex/config.toml:38-47` has `[features].goals = true`.
+5. `codex app-server --help` marks app-server as experimental and exposes protocol generation commands.
+
+## 5. Suggested Next Slice
+
+1. Add typed protocol drift check.
+   - Generate app-server TS bindings in a temp dir during a local script/test.
+   - Assert `ThreadGoal`, `ThreadGoalStatus`, and `ThreadGoalSetParams` still match the Codex++ local assumptions.
+   - Acceptance: fails loudly if native protocol renames fields or statuses.
+
+2. Ship command grammar expansion.
+   - Add explicit parsing for `set`, `budget`, `budget none`, `status`, and `done`.
+   - Acceptance: parser tests prove old `/goal <objective>` behavior still works.
+
+3. Convert the panel into a pill + popover.
+   - Keep existing app-server calls.
+   - Acceptance: screenshots for no goal, active goal, paused goal, budget-limited goal, and completed report at desktop and narrow widths.
+
+4. Add completion report.
+   - Detect transition to `complete`.
+   - Render objective, time, token usage, and budget summary.
+   - Acceptance: copyable report text is deterministic and includes exact numbers from `ThreadGoal`.
+
+5. Add local event journal.
+   - Record updated/cleared notifications with metadata only.
+   - Acceptance: current thread can show a goal history timeline after reload without storing chat content.
+
+6. Add templates and reminders after history is real.
+   - Templates need persistence.
+   - Reminders need dismiss/snooze state.
+   - Both should reuse the event journal rather than creating another state island.
+
+7. Prepare upstream app-server asks.
+   - `thread/goal/history/list`
+   - `thread/goal/list`
+   - optional `dueAt` / reminder fields
+   - explicit budget enforcement semantics
+   - stable feature detection for `thread/goal/*`

--- a/research/agents/multi-agent-workflows.md
+++ b/research/agents/multi-agent-workflows.md
@@ -1,0 +1,342 @@
+# Multi-Agent Workflow Product Notes
+
+Owned lane: Codex++ multi-agent orchestration inside Codex Desktop.
+
+Evidence anchors:
+
+- Codex++ can already inject renderer UI, Settings pages, and tweak lifecycle via `packages/runtime/src/preload/index.ts`, `settings-injector`, and `tweak-host`.
+- `packages/runtime/src/preload/app-server-bridge.ts` can send app-server requests and subscribe to app-server notifications from the renderer.
+- `packages/runtime/src/preload/goal-feature.ts` proves `thread/goal/get`, `thread/goal/set`, `thread/goal/clear`, and `thread/goal/*` notifications can drive thread-scoped UX.
+- `packages/runtime/src/main.ts` exposes Codex-native window/view creation through `api.codex.createWindow` and `api.codex.createBrowserView`.
+- `packages/runtime/src/mcp-sync.ts` can register tweak-provided MCP servers into Codex config.
+- `packages/runtime/src/git-metadata.ts` plus `api.git` provide metadata-only repository, status, diff, and worktree reads.
+
+## 1. Best Immediate Wins
+
+### 1.1 Agent Run Ledger
+
+Impact: high  
+Effort: medium  
+Confidence: high  
+Dependency: Codex++ runtime seam, app-server protocol
+
+Add a Codex++ Settings page or side panel that shows the current thread's agent work as an ordered ledger: parent turn, spawned subagents, pending waits, finished reports, changed files, commands run, and blockers. The first version can be passive and metadata-only: read current thread id from route, subscribe through the existing app-server notification bridge, and persist user-visible annotations in per-tweak storage.
+
+Why it matters: multi-agent work fails when orchestration state lives only in chat prose. A ledger makes it obvious which lanes are still running, which outputs are trusted, and which handoffs remain unintegrated.
+
+Implementation seams:
+
+- Renderer tweak with `api.settings.registerPage` for a first administrative surface.
+- `requestAppServer` and `onAppServerNotification` for current thread metadata and any available run events.
+- `api.storage` for ledger rows that are not yet present in upstream app-server state.
+- Later promotion to a dedicated route/window through `api.codex.createWindow`.
+
+EffectTS v4 shape:
+
+- Model rows with Effect Schema: `AgentRun`, `AgentEvent`, `AgentReport`, `AgentBlocker`.
+- Keep ingestion as a small Effect service boundary: `RunLedgerStore`, `AppServerEvents`, `ThreadContext`.
+- Avoid parsing raw transcript HTML in the core service. Keep DOM scraping as a replaceable adapter if needed.
+
+### 1.2 Subagent Report Inbox
+
+Impact: high  
+Effort: small  
+Confidence: high  
+Dependency: Codex++ runtime seam
+
+Create a report inbox that turns subagent final messages into structured cards: summary, findings, changed files, validation, residual risk, and next action. This should work even before Codex exposes rich subagent state by letting the parent agent paste or generate report blocks into the thread and having the tweak extract bounded report sections.
+
+Why it matters: today the parent must visually scan long chat history and remember what each explorer/worker returned. A compact report inbox makes integration and review faster without needing to own spawning yet.
+
+Implementation seams:
+
+- Renderer page in the Codex++ Tweaks sidebar.
+- Lightweight parser for explicit report fences or headings in visible thread text.
+- `api.storage` cache by `threadId + messageId` once message identity is available.
+- Optional "copy integration checklist" action that writes a concise parent-agent checklist to clipboard using existing IPC.
+
+Implementation note: the preferred durable path is not generic LLM summarization. Use an explicit report contract first, then add summarization only as a fallback.
+
+### 1.3 Handoff Summary Builder
+
+Impact: high  
+Effort: medium  
+Confidence: high  
+Dependency: Codex++ runtime seam, git.metadata
+
+Add a handoff builder for context-window recovery and thread continuation. It should gather cwd, repo root, git status, changed files, current goal, recently completed subagent report cards, commands run if available, unresolved blockers, and exact next actions into a compact Markdown artifact.
+
+Why it matters: Codex++ is already close to the user's recovery doctrine. A one-click handoff reduces saturated-thread failures and prevents bulk-dumping rollout logs into a new thread.
+
+Implementation seams:
+
+- Use `api.git.resolveRepository`, `api.git.getStatus`, `api.git.getDiffSummary`, and `api.git.getWorktrees` for metadata-only repo state.
+- Use existing `/goal` bridge for objective/status/tokens when the app-server supports goals.
+- Store handoff drafts in tweak storage keyed by thread id.
+- Provide copy-to-clipboard first; later add "open fresh Codex window with handoff prompt" through `api.codex.createWindow`.
+
+Acceptance check:
+
+- Generated handoff includes original thread id when available, cwd/repo root, current branch/SHA, dirty files, changed-file counts, active goal, blockers, and the next three actions.
+- It never embeds full logs, secrets, raw diffs, or unbounded transcript chunks by default.
+
+### 1.4 Goal Thread Header
+
+Impact: medium  
+Effort: small  
+Confidence: high  
+Dependency: app-server protocol
+
+Promote the existing `/goal` feature from floating panel into a persistent thread header chip: objective, status, budget usage, elapsed time, and quick actions for pause/resume/complete. This makes threaded goals visible without requiring users to type `/goal`.
+
+Why it matters: goals become useful orchestration state only when they remain visible during long runs.
+
+Implementation seams:
+
+- Reuse `thread/goal/get` and `thread/goal/set` from `goal-feature.ts`.
+- Reuse the route refresh logic that already tracks `threadId`.
+- Render into the existing Codex DOM with the same conservative mutation-observer approach as Settings injection.
+
+Constraint: keep the existing `/goal` command as the source of truth for the first slice. The header should be a view/controller, not a parallel goal store.
+
+### 1.5 Review Lane Checklist
+
+Impact: high  
+Effort: medium  
+Confidence: medium  
+Dependency: Codex++ runtime seam, git.metadata
+
+Add a review-lane panel that turns a multi-agent code task into explicit review lanes: diff review, tests, docs, visual proof, security/trust boundary, PR description, and unresolved questions. Each lane can be assigned to "parent", "explorer", or "worker" and marked blocked/ready/done.
+
+Why it matters: multi-agent output is only useful if the parent can see what still needs human-quality integration. This also maps cleanly to the repo's PR evidence standard.
+
+Implementation seams:
+
+- Start as local checklist state in `api.storage`.
+- Prepopulate lanes from git status and file types via `api.git.getStatus`.
+- Add optional report-card links from the Subagent Report Inbox.
+- Later connect to GitHub PR state through MCP or CLI-backed tweak permissions.
+
+## 2. Medium Bets
+
+### 2.1 Task DAG Canvas
+
+Impact: high  
+Effort: large  
+Confidence: medium  
+Dependency: Codex++ runtime seam
+
+Build a DAG view where nodes are tasks, subagents, validation lanes, blockers, and handoffs. Edges represent "blocks", "verifies", "integrates", or "supersedes". The first useful version should be dense and operational, not a decorative canvas.
+
+Why it matters: the parent agent needs a working map of what is parallelizable versus what is on the critical path. A DAG prevents duplicated work, idle waits, and stale blockers.
+
+Implementation seams:
+
+- Dedicated Settings page first; later a detached Codex++ window through `api.codex.createWindow`.
+- Store graph state in tweak storage as normalized tables: nodes, edges, statuses, evidence refs.
+- Import from handoff summary and report inbox.
+- Export to Markdown so the graph survives without the UI.
+
+Dependency candidates:
+
+- Use EffectTS v4 services and Schema for graph validation, cycle detection, and stale status checks.
+- Consider React Flow or a similarly maintained graph renderer only after the data model is stable. Keep graph computation independent of the view dependency.
+
+Acceptance check:
+
+- Detect cycles.
+- Detect nodes with missing owner/status.
+- Highlight current critical path.
+- Show "ready to spawn" nodes separately from "blocked until report arrives" nodes.
+
+### 2.2 Spawn Plan Composer
+
+Impact: high  
+Effort: large  
+Confidence: medium  
+Dependency: native Codex seam, app-server protocol
+
+Create a composer assistant that turns a broad task into bounded subagent prompts with role, ownership boundary, write scope, worktree guidance, report contract, and validation expectations. The first version should generate prompts for manual spawning; later versions can call a native spawn API if Codex exposes one.
+
+Why it matters: spawning is powerful but failure-prone. The real product leverage is making each delegated lane bounded, non-overlapping, and reviewable.
+
+Implementation seams:
+
+- UI uses current thread goal plus git dirty state to warn about unsafe write scopes.
+- Prompt templates live as data, not hard-coded prose, so teams can tune conventions.
+- Manual mode: copy prompts to clipboard.
+- Native mode, if available later: route through app-server request bridge or an MCP tool registered by Codex++.
+
+Report contract:
+
+- Each prompt should require: changed files, commands run, final status, blockers, exact next action, and whether it touched only the assigned ownership boundary.
+
+### 2.3 Worktree Fleet Manager
+
+Impact: high  
+Effort: large  
+Confidence: medium  
+Dependency: git.metadata, Codex++ runtime seam
+
+Add a manager for multi-agent worktrees: golden worktree source, fresh child worktrees, branch naming, dirty state, lock reason, stale/prunable detection, and per-lane ownership notes.
+
+Why it matters: the user explicitly wants new worktrees copied from a golden ready-to-run checkout to avoid setup tax and clashes. Codex++ can surface this inside the app before adding mutating operations.
+
+Implementation seams:
+
+- Read-only first with `api.git.getWorktrees`.
+- Add metadata notes in tweak storage: owner lane, purpose, linked thread, linked report.
+- Mutating operations should require a new explicit permission, for example `git.worktree.write`, and should run in main with `spawn(..., { shell: false })`.
+- For "copy golden" implementation, prefer a repo-local script or a Codex++ installer-managed helper instead of ad hoc shell strings in renderer code.
+
+Risk:
+
+- Worktree creation can destroy productivity if it touches the wrong path. Keep mutation out of the first slice and show the exact command preview before any future write path.
+
+### 2.4 Agent Dashboard Window
+
+Impact: medium  
+Effort: medium  
+Confidence: medium  
+Dependency: native Codex seam
+
+Use `api.codex.createWindow` to create a dedicated dashboard window for long-running orchestration: active threads, goals, subagent reports, handoff drafts, and review lanes. The dashboard should be separate from Settings once the product is used daily.
+
+Why it matters: Settings is good for MVP, but orchestration is primary work. A dashboard window lets the user keep command/chat visible while the supervisor state stays open.
+
+Implementation seams:
+
+- Start from a Settings page.
+- Promote to native Codex window when routing and layout are proven.
+- Keep all data services shared so Settings and dashboard are two views over the same store.
+
+### 2.5 Evidence Index
+
+Impact: medium  
+Effort: medium  
+Confidence: medium  
+Dependency: Codex++ runtime seam, git.metadata
+
+Create an evidence index for a thread: commands run, screenshots, changed files, PR links, failing checks, passing checks, and source anchors. This is the substrate for high-quality PR descriptions and final answers.
+
+Implementation seams:
+
+- Pull git state from `api.git`.
+- Let users attach file paths or clipboard snippets manually first.
+- Later ingest terminal/session events if Codex exposes them.
+- Export reviewer-facing PR evidence sections.
+
+Constraint:
+
+- Do not auto-claim checks passed. Evidence rows need status, timestamp, command, and result summary.
+
+## 3. Wild Ideas Or Moonshots
+
+### 3.1 Meta-Supervisor Mode
+
+Impact: moonshot  
+Effort: large  
+Confidence: low  
+Dependency: native Codex seam, app-server protocol
+
+Add a supervisor mode that continuously evaluates the active thread's orchestration health: missing plan, too-serial execution, stale subagent, unbounded prompt, conflicting write scopes, missing validation, or unsafe finalization. It should suggest interventions and generate bounded prompts rather than silently taking action.
+
+Implementation seams:
+
+- Start as deterministic rules over the ledger, DAG, reports, and git state.
+- Add model-assisted critique only after the deterministic states are reliable.
+- Make all suggestions auditable: input facts, rule fired, suggested action.
+
+### 3.2 Threaded Goal Graph
+
+Impact: moonshot  
+Effort: large  
+Confidence: medium  
+Dependency: app-server protocol
+
+Extend single-thread goals into a goal graph: parent objective, child objectives, budgets, dependencies, completion criteria, and handoff links. The UI should show which thread owns which part of a larger objective.
+
+Implementation seams:
+
+- Use existing `thread/goal/*` as node-local state.
+- Store cross-thread graph in Codex++ storage until upstream supports it.
+- Include import/export so graph state can be carried between machines or threads.
+
+Risk:
+
+- Split-brain state if upstream eventually owns cross-thread goals. Keep IDs and schema versioned from day one.
+
+### 3.3 Auto-Handoff Fresh Thread Launcher
+
+Impact: moonshot  
+Effort: large  
+Confidence: low  
+Dependency: native Codex seam
+
+When context saturation is detected or requested, generate a handoff, open a fresh Codex window/thread, seed the handoff as the first prompt, and keep a back-link to the archival thread.
+
+Implementation seams:
+
+- Handoff Summary Builder is prerequisite.
+- Needs a reliable native route or compose API. Until then, only copy the prompt and open a fresh window.
+- Must avoid copying old saturated model-visible history.
+
+### 3.4 Multi-Agent Replay
+
+Impact: moonshot  
+Effort: research  
+Confidence: low  
+Dependency: external service, app-server protocol
+
+Replay a completed multi-agent session as a timeline with decisions, reports, edits, checks, and final state. Useful for training future agents, debugging bad orchestration, and creating reusable runbooks.
+
+Implementation seams:
+
+- Event model from Agent Run Ledger.
+- Evidence Index for command/check attachments.
+- Export as compact JSONL plus Markdown summary.
+
+## 4. Constraints And Exact Evidence
+
+Current product constraints:
+
+- Codex++ is a local patch/runtime system, not a fork of Codex Desktop. Durable features should prefer preload, app-server bridge, settings injection, and main-process APIs over minified bundle patching.
+- Renderer code should not shell out. Main-process services already own git metadata and should own any future mutating filesystem/git operations.
+- Existing public tweak permissions do not include agent orchestration, transcript access, terminal event access, or git mutation. New sensitive surfaces should be permission-gated.
+- `thread/goal/*` exists in the local context but can fail on older app-server builds or when the goals feature is disabled. Goal-based UX needs graceful degradation.
+- Worktree and subagent mutation has high blast radius. First slices should be read-only, copy-to-clipboard, or explicit command-preview flows.
+
+Useful existing seams:
+
+- UI: `api.settings.registerPage`, Settings injector, DOM/fiber utilities.
+- Native windowing: `api.codex.createWindow`, `api.codex.createBrowserView`.
+- App-server: `requestAppServer`, `onAppServerNotification`, host id and thread route helpers in `goal-feature.ts`.
+- Local persistence: per-tweak storage under user data.
+- Git metadata: repository resolution, status, diff summary, worktrees.
+- MCP: tweak manifests can declare MCP servers that Codex++ syncs into `~/.codex/config.toml`.
+
+Data contracts to establish before implementation:
+
+- `ThreadRef`: host id, thread id, route, cwd/project path if known.
+- `AgentRun`: id, parent thread, role, status, created/updated timestamps, ownership boundary.
+- `AgentReport`: run id, summary, files changed, commands run, findings, blockers, next actions.
+- `TaskNode`: id, title, owner, status, dependencies, acceptance checks, evidence refs.
+- `HandoffSummary`: source thread, repo metadata, goal state, changed files, completed reports, blockers, next actions.
+
+## 5. Suggested Next Slice
+
+Build the read-only orchestration MVP in this order:
+
+1. Add an internal data model for `ThreadRef`, `AgentReport`, `TaskNode`, and `HandoffSummary` using EffectTS v4 Schema in a future implementation slice.
+2. Implement Subagent Report Inbox as a Settings page with explicit report-block parsing and per-thread storage.
+3. Implement Handoff Summary Builder using report cards, current goal state, and `api.git` metadata.
+4. Add Review Lane Checklist seeded from changed file types and linked to report cards.
+5. Promote the most-used surface into a dedicated Agent Dashboard window after the Settings-page UX proves useful.
+
+Definition of done for the first implementation PR:
+
+- No mutating git/worktree operations.
+- No raw transcript or log bulk capture.
+- Works when `thread/goal/*` is unavailable by omitting goal state with a clear local note.
+- Generated handoff is bounded, copyable, and includes exact repo metadata from `api.git`.
+- PR includes screenshots because this is UI-affecting work.

--- a/research/agents/native-ui.md
+++ b/research/agents/native-ui.md
@@ -1,0 +1,337 @@
+# Native-Feeling UI Opportunities
+
+Scope: Codex++ over Codex Desktop, with focus on slash menu, composer, thread
+header, sidebar, settings, overlays, and React/fiber seams. This lane only
+studied and documented opportunities; no runtime or tweak code was changed.
+
+## 1. Easy Wins
+
+1. Make the `/goal` shim the prototype for a general slash-command registry.
+   - Impact: high
+   - Effort: small to medium
+   - Confidence: high
+   - Dependency: Codex++ runtime seam, app-server protocol
+   - Notes: `goal-feature.ts` already listens at capture phase, detects
+     editable composer targets, renders an anchored suggestion, applies text on
+     Tab/Enter, and intercepts `/goal ...` before Codex sends it. Generalize
+     that into `api.composer.registerSlashCommand({ name, label, detail,
+     run })` instead of keeping `/goal` as a one-off.
+   - Native-feeling constraint: keep suggestions anchored to the real composer
+     rect, keyboard-first, and visually token-aligned. Do not build a floating
+     global command palette until the composer route is proven.
+
+2. Add a composer target helper before adding more composer features.
+   - Impact: high
+   - Effort: small
+   - Confidence: high
+   - Dependency: Codex++ runtime seam
+   - Notes: today each feature would need to rediscover textarea,
+     contenteditable, and `[role="textbox"]` behavior. Promote the existing
+     `EditableTarget` logic into a shared private helper, then expose a narrow
+     public API later. This reduces duplicate DOM heuristics and keeps future
+     composer chips, slash commands, and prompt transforms consistent.
+   - Native-feeling constraint: preserve Codex's own input events and selection
+     semantics; use the same `InputEvent` pattern already proven by `/goal`.
+
+3. Turn Settings page injection into the stable home for heavier tweak UIs.
+   - Impact: high
+   - Effort: small
+   - Confidence: high
+   - Dependency: Codex++ runtime seam
+   - Notes: `settings.registerPage` already injects real sidebar entries under
+     a "TWEAKS" group and lets page-owning tweaks render full panels. This is
+     the right place for feature configuration, keyboard shortcuts, UI
+     improvement toggles, slash-command settings, and debug inspectors.
+   - Native-feeling constraint: copy Codex's sidebar item classes and token
+     variables, but centralize that copying in runtime helpers so tweaks do not
+     each clone class strings.
+
+4. Publish a native overlay helper for small transient panels.
+   - Impact: medium
+   - Effort: small
+   - Confidence: high
+   - Dependency: Codex++ runtime seam
+   - Notes: `/goal` already has a fixed bottom-right panel with actions,
+     transient notices, and errors. Make a single overlay host that supports
+     anchored composer suggestions, toast-like panels, and modal-ish confirms.
+   - Native-feeling constraint: use one z-index owner, escape handling, focus
+     return, and collision logic. Multiple tweaks should not independently
+     append `z-index: 2147483647` panels to `document.body`.
+
+5. Keep sidebar refinements as token-based DOM marking, not synthetic rewrites.
+   - Impact: medium
+   - Effort: small
+   - Confidence: medium to high
+   - Dependency: native Codex seam
+   - Notes: Bennett's UI tweak has already proven useful sidebar changes:
+     usage in sidebar, matched settings sidebar width, a compact action grid,
+     and project row backgrounds. The lowest-risk pattern is to mark existing
+     nodes and add token-based CSS. Synthetic replacement buttons should stay
+     reserved for features that cannot be expressed by styling existing nodes.
+
+## 2. Medium Bets
+
+1. Add `api.ui` primitives: composer, overlay, sidebar, settings, route.
+   - Impact: high
+   - Effort: medium
+   - Confidence: medium
+   - Dependency: Codex++ runtime seam
+   - Notes: the public SDK currently exposes `settings`, `react`, `ipc`, `fs`,
+     `storage`, `git`, and main-side `codex` hooks, but no first-class UI
+     surface beyond Settings. A small `api.ui` would prevent every tweak from
+     learning the same fragile Codex DOM.
+   - Proposed shape:
+     - `api.ui.composer.onCommand(prefix, handler)`
+     - `api.ui.overlay.show(anchor | fixed, render, options)`
+     - `api.ui.sidebar.findMainSidebar()`
+     - `api.ui.route.getThreadId()`
+     - `api.ui.settingsSurface.subscribe()`
+   - Constraint: keep the first version imperative and DOM-native. Do not
+     expose React itself; the current SDK intentionally avoids that.
+
+2. Build a thread header enrichment lane.
+   - Impact: high
+   - Effort: medium
+   - Confidence: medium
+   - Dependency: native Codex seam, app-server protocol, React/fiber seam
+   - Notes: thread header is the right place for goal status, repo/branch,
+     run mode, model, active worktree, and token budget. Today `/goal` floats
+     status in an overlay because there is no stable header mount. The next
+     slice should identify the header DOM/fiber owner and add a read-only chip
+     region before attempting controls.
+   - Constraint: header chips must be passive first. Any mutating controls
+     should call app-server/runtime APIs and show reversible pending states.
+
+3. Make git metadata visible in the sidebar and thread header.
+   - Impact: high
+   - Effort: medium
+   - Confidence: high for data, medium for native placement
+   - Dependency: Codex++ runtime seam, native Codex seam
+   - Notes: the git metadata provider already returns structured repo status,
+     ahead/behind, diff summary, and linked worktrees without raw diff hunks.
+     Use it for a compact branch/dirty header and file/list badges.
+   - Constraint: keep mutating git operations out of scope. This should remain
+     metadata-only and poll-backed until route and file-list anchors are stable.
+
+4. Provide a fiber-inspector research tweak for Codex UI seams.
+   - Impact: medium
+   - Effort: medium
+   - Confidence: medium
+   - Dependency: React/fiber seam
+   - Notes: the runtime captures React renderer internals before Codex mounts,
+     and exposes `getFiber`, `findOwnerByName`, and `waitForElement`. A
+     developer-only inspector could record component names, owner chains, props
+     keys, and stable DOM anchors for composer, thread header, sidebar rows,
+     settings, and overlays.
+   - Constraint: never persist raw prompt text, messages, secrets, or full props
+     by default. Store component names and redacted prop-key summaries.
+
+5. Normalize native settings and main-sidebar width/spacing behavior.
+   - Impact: medium
+   - Effort: medium
+   - Confidence: high
+   - Dependency: native Codex seam
+   - Notes: the default UI tweak already fixes settings sidebar width mismatch
+     and layout jumps. Move the underlying measurements and token CSS into a
+     reusable runtime helper so other tweaks can mount UI without fighting the
+     same shell geometry.
+
+6. Bridge app-server notifications into UI state stores.
+   - Impact: medium
+   - Effort: medium
+   - Confidence: medium
+   - Dependency: app-server protocol
+   - Notes: `app-server-bridge.ts` can send `mcp-request` messages and receive
+     notifications. `/goal` already consumes `thread/goal/updated` and
+     `thread/goal/cleared`. A small typed notification registry would let UI
+     modules subscribe to thread events without copying response extraction
+     logic.
+   - Constraint: every request needs timeout, hostId handling, and graceful
+     fallback for older Codex/app-server builds.
+
+## 3. Moonshots
+
+1. Native command palette augmentation.
+   - Impact: moonshot
+   - Effort: large
+   - Confidence: low to medium
+   - Dependency: React/fiber seam, native Codex seam
+   - Notes: instead of building a separate palette, locate Codex's existing
+     command bar (`Cmd+K` is seeded by the keyboard tweak) and append Codex++
+     actions into the same command model. This would feel more native than a
+     duplicate overlay, but it requires stronger fiber or app-state access.
+
+2. First-class right-side inspector panel.
+   - Impact: moonshot
+   - Effort: large
+   - Confidence: medium
+   - Dependency: main Codex window/view services
+   - Notes: main-side `codex.createBrowserView` and `codex.createWindow` can
+     create Codex-routed surfaces through Desktop's own window services. A
+     persistent inspector panel could show goal, git, task DAG, run logs, and
+     tweak debug state without crowding the chat.
+   - Constraint: BrowserView lifecycle, focus, route sync, and parent window
+     resizing need proof before exposing this to general tweak authors.
+
+3. Semantic UI hook registry for Codex Desktop.
+   - Impact: moonshot
+   - Effort: large
+   - Confidence: medium
+   - Dependency: React/fiber seam
+   - Notes: maintain a versioned map of native surfaces: composer, header,
+     thread list, file tree, message row, settings sidebar, popover/menu root.
+     Each entry would have selectors, text heuristics, fiber owner names, and
+     screenshot proof for the current Codex Desktop build.
+   - Constraint: must be generated or verified by a small inspector/test suite,
+     not hand-maintained forever.
+
+4. Tweak-owned mini apps using native Codex routes.
+   - Impact: moonshot
+   - Effort: large
+   - Confidence: low
+   - Dependency: main Codex window/view services, app-server protocol
+   - Notes: create routed native-feeling Codex++ surfaces for task graphs,
+     screenshots, review queue, and automation dashboards. This is possible if
+     window services stay available, but it is a later bet after overlay and
+     settings primitives are stable.
+
+## 4. Constraints And Evidence Anchors
+
+1. Codex++ currently injects through Electron preload, not source patches.
+   - Evidence: `docs/ARCHITECTURE.md:47-75` describes loader, main runtime,
+     renderer preload, settings injector, and tweak host boot.
+   - Evidence: `docs/ARCHITECTURE.md:87-90` says Codex is a Vite/Rollup build
+     with no exposed module registry, so preload plus DOM observation is the
+     intended stability boundary.
+
+2. The runtime reaches every sandboxed renderer through Electron preload.
+   - Evidence: `packages/runtime/src/main.ts:351-384` uses
+     `session.registerPreloadScript` with a `setPreloads` fallback.
+   - Evidence: `packages/runtime/src/main.ts:395-414` logs new webContents and
+     preload errors, including sandbox/contextIsolation status.
+   - Evidence: local `main.log` on 2026-05-01 shows sandboxed renderer windows
+     and successful `registerPreloadScript` registration.
+
+3. Renderer tweaks are sandboxed and evaluated from source strings.
+   - Evidence: `packages/runtime/src/preload/tweak-host.ts:1-13` explains that
+     Codex renderers run with `sandbox: true`, so arbitrary disk `require()` is
+     unavailable and tweak source is evaluated in preload context.
+   - Evidence: `packages/runtime/src/preload/tweak-host.ts:104-123` reads tweak
+     source via IPC and evaluates it with `new Function`.
+
+4. Settings is currently the strongest native UI surface.
+   - Evidence: `packages/runtime/src/preload/settings-injector.ts:1-21` says
+     Codex settings is a routed page, not a modal, and the injector finds the
+     sidebar by known labels because there are no stable role/testid hooks.
+   - Evidence: `packages/runtime/src/preload/settings-injector.ts:169-200`
+     observes DOM and history navigation to inject/reinject settings UI.
+   - Evidence: `packages/runtime/src/preload/settings-injector.ts:298-371`
+     injects a "Codex++" sidebar group with Config and Tweaks entries.
+   - Evidence: `packages/runtime/src/preload/settings-injector.ts:431-495`
+     lazily injects a per-tweak "TWEAKS" group for `registerPage`.
+   - Evidence: `packages/runtime/src/preload/settings-injector.ts:497-510`
+     copies Codex sidebar item classes for native visual fit.
+
+5. The composer/slash seam is real but currently private and goal-specific.
+   - Evidence: `packages/runtime/src/preload/goal-feature.ts:36-78` installs
+     capture listeners and app-server goal notifications.
+   - Evidence: `packages/runtime/src/preload/goal-feature.ts:80-119`
+     intercepts Tab/Enter and `/goal` submissions before Codex handles them.
+   - Evidence: `packages/runtime/src/preload/goal-feature.ts:397-448` renders
+     a suggestion anchored to the editable target's bounding rect.
+   - Evidence: `packages/runtime/src/preload/goal-feature.ts:594-644`
+     supports textarea, text/search input, contenteditable, and `[role=textbox]`.
+   - Evidence: `packages/runtime/src/preload/goal-feature.ts:656-670`
+     derives thread id from route, hash, href, `initialRoute`, and history
+     state.
+
+6. App-server bridge exists and should be reused for thread-native state.
+   - Evidence: `packages/runtime/src/preload/app-server-bridge.ts:29-66`
+     sends `mcp-request` envelopes through `codex_desktop:message-from-view`
+     with request ids, hostId, and timeout handling.
+   - Evidence: `packages/runtime/src/preload/app-server-bridge.ts:68-118`
+     subscribes to `codex_desktop:message-for-view`, extracts notifications,
+     and resolves responses.
+   - Evidence: extracted installed `preload.js` from Codex Desktop
+     `26.429.20946` exposes `electronBridge.sendMessageFromView` on the same
+     channel and dispatches incoming app-server messages to `window`.
+
+7. React/fiber seam is available but unstable by nature.
+   - Evidence: `packages/runtime/src/preload/react-hook.ts:1-10` installs a
+     React DevTools-shaped hook to capture renderer internals before mount.
+   - Evidence: `packages/runtime/src/preload/react-hook.ts:88-102` resolves a
+     fiber from renderer internals or `__reactFiber*` DOM properties.
+   - Evidence: `packages/runtime/src/preload/tweak-host.ts:177-205` exposes
+     `getFiber`, `findOwnerByName`, and `waitForElement` to renderer tweaks.
+   - Constraint: fiber names and owner chains can change on Codex updates, so
+     this is best for discovery and guarded enrichments, not the first line of
+     production UI integration.
+
+8. Sidebar DOM is useful but brittle.
+   - Evidence: Bennett's installed UI tweak documents that Codex's shell lacks
+     stable testids/aria labels for many widgets and uses text-content matching
+     for resilience.
+   - Evidence: installed `co.bennett.ui-improvements/index.js:173-180` ranks
+     sidebar candidates by geometry and semantic hints.
+   - Evidence: installed `co.bennett.ui-improvements/index.js:1566-1575`
+     describes project rows as `div[role=listitem]` with `group/cwd` classes
+     and favors marking existing nodes plus token CSS.
+
+9. Native app window/view services are already partially exposed to main tweaks.
+   - Evidence: `packages/runtime/src/main.ts:907-935` creates BrowserViews
+     through Codex window services and registers them with the window manager.
+   - Evidence: `packages/runtime/src/main.ts:937-988` creates/focuses native
+     Codex windows by route, hostId, appearance, parent, and bounds.
+   - Constraint: this is powerful but main-process-only and must remain behind
+     explicit capabilities because it can affect focus, windows, and app chrome.
+
+10. Existing default tweaks are already pushing toward native UI.
+    - Evidence: local `main.log` shows two installed tweaks:
+      `co.bennett.custom-keyboard-shortcuts` and `co.bennett.ui-improvements`.
+    - Evidence: `co.bennett.custom-keyboard-shortcuts/index.js:1-29` discovers,
+      remaps, and disables shortcuts, while explicitly excluding native app-menu
+      accelerators from renderer scope.
+    - Evidence: `co.bennett.custom-keyboard-shortcuts/index.js:111-146` seeds
+      shortcuts including sidebar, command bar, settings, model picker, terminal,
+      file tree, and send message.
+
+## 5. Recommended UI Strategy
+
+1. Treat Settings as the stable configuration plane.
+   - Keep all heavy tweak UI in `registerPage` surfaces.
+   - Move copied classes and token styling into runtime helpers.
+   - Add screenshot-based proof for settings pages whenever pixels change.
+
+2. Promote `/goal` into a small composer/slash-command platform.
+   - First extract private shared helpers: editable target, thread id, anchored
+     suggestion root, keyboard interception, and app-server error handling.
+   - Then expose a narrow `api.ui.composer` registry to tweaks.
+   - Start with read-only or app-server-backed commands; avoid command actions
+     that synthesize arbitrary chat sends.
+
+3. Build one overlay manager before adding more overlays.
+   - Centralize z-index, focus return, escape behavior, collision positioning,
+     and cleanup.
+   - Use it for slash suggestions, goal panels, warning notices, and future
+     mini inspectors.
+
+4. Use native DOM first, fiber second, source patching never by default.
+   - DOM/text/role geometry is best for broad compatibility.
+   - Fiber is best for finding better anchors and reading stable prop keys.
+   - Source patching is last resort because Codex's bundle is minified and
+     update-sensitive.
+
+5. Add a discovery harness before deeper native UI work.
+   - A developer-only tweak should inspect composer, header, sidebar, settings,
+     message rows, and popovers, then write redacted evidence under
+     `research/evidence/`.
+   - It should record selectors, bounding boxes, owner component names, and
+     screenshots, not raw user content.
+
+6. Next implementation slice:
+   - Implement internal shared composer helpers from `goal-feature.ts`.
+   - Add an internal overlay host and migrate `/goal` to it.
+   - Add a dev-only fiber/DOM evidence tweak for thread header and sidebar
+     anchors.
+   - After screenshots prove those anchors, expose `api.ui.composer` and
+     `api.ui.overlay` in the SDK.

--- a/research/agents/observability.md
+++ b/research/agents/observability.md
@@ -1,0 +1,329 @@
+# Codex++ Observability Product Notes
+
+## 1. Best immediate wins
+
+### 1. In-app live log console
+
+- Impact: high
+- Effort: small
+- Confidence: high
+- Dependency: Codex++ runtime seam
+
+Ship a first-class "Observability" page under the existing Codex++ settings group that tails `main.log`, `preload.log`, `loader.log`, and the platform watcher log. The current manager can only reveal the log directory, which is useful for bug reports but too slow for live debugging.
+
+Evidence anchors:
+
+- `packages/runtime/src/logging.ts:3-25` caps appended runtime log files at 10 MiB.
+- `packages/runtime/src/main.ts:39-40` defines the runtime log directory and `main.log`.
+- `packages/runtime/src/main.ts:527-532` forwards sandboxed preload log lines into `preload.log`.
+- `packages/runtime/src/preload/index.ts:19-33` already emits preload boot stages via IPC.
+- `packages/runtime/src/preload/settings-injector.ts:1100-1113` asks users to attach relevant log lines when filing a bug, but does not surface them inline.
+
+Shippable slice:
+
+1. Add a read-only IPC handler that returns the last N lines for known log files only.
+2. Render a compact table with time, source, level, message, and "copy visible lines".
+3. Poll every 1 to 2 seconds only while the page is visible.
+4. Redact obvious tokens, absolute home subpaths behind `~`, and long base64/data URLs before display.
+
+### 2. Runtime health strip
+
+- Impact: high
+- Effort: small
+- Confidence: high
+- Dependency: Codex++ runtime seam
+
+Add a top-level runtime health strip showing whether the preload is registered, renderer boot completed, tweak host loaded, settings injector mounted, hot reload is idle, remote debug is enabled, and the app-server bridge has pending requests. This should be the "is Codex++ alive?" answer before the user reads raw logs.
+
+Evidence anchors:
+
+- `packages/runtime/src/main.ts:351-383` registers the preload and logs success or failure.
+- `packages/runtime/src/main.ts:386-416` logs every `web-contents-created` event plus preload errors.
+- `packages/runtime/src/preload/index.ts:67-80` has explicit boot stages and a boot failure path.
+- `packages/runtime/src/preload/tweak-host.ts:53-84` loads renderer tweaks and logs the loaded tweak count.
+- `packages/runtime/src/main.ts:591-610` supports manual reload plus debounced tweak reload.
+
+Shippable slice:
+
+1. Keep an in-memory `RuntimeHealthSnapshot` in main with `lastPreloadRegistration`, `lastWebContents`, `lastPreloadBoot`, `lastTweakHostLoad`, `lastReload`, and `lastError`.
+2. Update the snapshot from existing log call sites before building a larger telemetry bus.
+3. Expose it through `codexpp:get-runtime-health`.
+4. Render one compact status row above the live logs.
+
+### 3. App-server request timeline
+
+- Impact: high
+- Effort: medium
+- Confidence: high
+- Dependency: app-server protocol
+
+Instrument Codex++ app-server calls at the bridge boundary. The bridge already sees method, host id, request id, request start, response, notifications, timeouts, and errors. A timeline here would explain "why did `/goal` hang?", "which app-server method is noisy?", and "what native Codex events did we receive?" without reverse-engineering every Codex internal route.
+
+Evidence anchors:
+
+- `packages/runtime/src/preload/app-server-bridge.ts:3-5` names Codex desktop message channels and the default 12 second timeout.
+- `packages/runtime/src/preload/app-server-bridge.ts:29-65` creates app-server requests, assigns Codex++ request ids, tracks pending requests, and handles invoke failures.
+- `packages/runtime/src/preload/app-server-bridge.ts:86-118` subscribes to app-server messages and resolves or rejects pending requests.
+- `packages/runtime/src/preload/app-server-bridge.ts:155-173` normalizes notifications into `{ method, params }`.
+- `packages/runtime/src/preload/goal-feature.ts:187-203` already uses `thread/goal/set` and `thread/goal/get`.
+
+Shippable slice:
+
+1. Add a renderer-local ring buffer in `app-server-bridge.ts` for request and notification events.
+2. Store method, id, hostId, start/end time, duration, status, error message, and a redacted parameter shape.
+3. Dispatch a DOM event or expose a debug getter consumed by the Observability page.
+4. Show requests as a waterfall grouped by host id and method.
+
+### 4. Goal token and budget telemetry
+
+- Impact: high
+- Effort: small
+- Confidence: high
+- Dependency: app-server protocol
+
+Promote `/goal` token and elapsed-time fields from a transient panel into a persistent debug view. This gives Codex++ an immediate token/budget telemetry story without needing model-provider billing hooks.
+
+Evidence anchors:
+
+- `packages/runtime/src/preload/goal-feature.ts:3-14` defines `ThreadGoal` with `tokenBudget`, `tokensUsed`, and `timeUsedSeconds`.
+- `packages/runtime/src/preload/goal-feature.ts:53-70` listens for `thread/goal/updated` and `thread/goal/cleared` notifications.
+- `packages/runtime/src/preload/goal-feature.ts:255-264` renders current token usage and elapsed time in the goal panel.
+- `research/README.md:22-27` records that the current patched Codex Desktop build exposes `codex-cli 0.128.0-alpha.1`, the `goals` flag, and `thread/goal/*` support.
+
+Shippable slice:
+
+1. Add the current goal to the runtime health snapshot.
+2. Render budget used, budget remaining, elapsed time, and burn rate.
+3. Add warning states at 75 percent and 95 percent budget usage.
+4. Keep this per-thread and do not aggregate across projects until the underlying app-server contract is better understood.
+
+### 5. Patch, update, and watcher health dashboard
+
+- Impact: high
+- Effort: small
+- Confidence: high
+- Dependency: Codex++ runtime seam
+
+Unify CLI `status`, CLI `doctor`, in-app watcher health, and Codex++ self-update state into one patch health dashboard. Users should be able to answer "am I patched?", "will repair run after a Codex update?", "is update mode active?", and "what should I run next?" from the app.
+
+Evidence anchors:
+
+- `packages/runtime/src/watcher-health.ts:38-90` produces a structured watcher health summary from `state.json`, `config.json`, app path, and platform checks.
+- `packages/runtime/src/watcher-health.ts:196-206` scans the watcher log tail for recent errors.
+- `packages/runtime/src/preload/settings-injector.ts:736-743` already renders an Auto-Repair Watcher section.
+- `packages/runtime/src/preload/settings-injector.ts:991-1043` renders watcher status and a "Check Now" action.
+- `packages/installer/src/commands/status.ts:12-85` prints user dirs, install state, current app version, update mode, asar hash match, plist hash, and fuse state.
+- `packages/installer/src/commands/doctor.ts:15-81` checks writable user dir, app presence, asar hash, code signature, and runtime/tweaks/log dirs.
+
+Shippable slice:
+
+1. Move the status/doctor facts into a shared JSON-producing health module instead of duplicating CLI-only output.
+2. Extend `codexpp:get-watcher-health` or add `codexpp:get-patch-health`.
+3. Render failed checks first with exact command suggestions: `codexplusplus repair`, `codexplusplus doctor`, or `codexplusplus update-codex`.
+4. Include "last successful repair/runtime refresh" from `state.json`.
+
+### 6. Error inbox
+
+- Impact: medium
+- Effort: small
+- Confidence: high
+- Dependency: Codex++ runtime seam
+
+Collect main-process uncaught exceptions, preload boot failures, app-server timeout errors, tweak load failures, watcher failures, and update-check failures into a small deduped error inbox. This is more actionable than forcing users to scan four logs.
+
+Evidence anchors:
+
+- `packages/runtime/src/main.ts:263-269` logs main-process uncaught exceptions and unhandled rejections.
+- `packages/runtime/src/preload/index.ts:78-80` logs preload boot failures.
+- `packages/runtime/src/preload/tweak-host.ts:65-73` logs renderer tweak load failures.
+- `packages/runtime/src/preload/app-server-bridge.ts:40-43` emits app-server request timeouts.
+- `packages/runtime/src/preload/settings-injector.ts:823` logs Codex++ update-check failures.
+- `packages/runtime/src/watcher-health.ts:200-205` detects watcher-log errors.
+
+Shippable slice:
+
+1. Parse recent known log files into normalized `ObservedError` records.
+2. Deduplicate by source, message prefix, and stack top frame.
+3. Render severity, first seen, last seen, count, and suggested next command.
+4. Add "copy bug report bundle" with health snapshot plus redacted recent errors.
+
+## 2. Medium bets
+
+### 7. Tool-call timeline from app-server and renderer events
+
+- Impact: high
+- Effort: research
+- Confidence: medium
+- Dependency: app-server protocol
+
+Build a timeline that correlates user prompt submission, app-server notifications, tool calls, filesystem mutations, git status changes, patch application, and renderer updates. Start with events Codex++ already owns, then add app-server notification decoders as real observed method names are cataloged.
+
+Evidence anchors:
+
+- `packages/runtime/src/preload/app-server-bridge.ts:155-173` can capture all notifications even before Codex++ understands their payloads.
+- `packages/runtime/src/git-metadata.ts` exists as the local git metadata provider for file/worktree state.
+- `docs/GIT_METADATA_SIDEBAR.md:80-87` explicitly wants status refresh on sidebar open, focus regain, route/thread change, and after Codex tool calls that write files.
+- `packages/runtime/src/main.ts:845-856` broadcasts tweak reloads to all web contents.
+
+Shippable slice:
+
+1. Introduce an append-only local timeline store with event type, timestamp, thread id when known, host id, and redacted payload shape.
+2. Emit first-party Codex++ events: boot, preload, tweak load, reload, app-server request/response, notification, git refresh, patch repair.
+3. Render as a swimlane view: Renderer, Main, App-server, Tools, Git, Updater.
+4. Add decoders only for observed app-server methods; unknown methods stay visible as raw method names with redacted shapes.
+
+### 8. Optional OpenTelemetry export
+
+- Impact: medium
+- Effort: medium
+- Confidence: medium
+- Dependency: external service
+
+Use a local-first event model that can later export to OpenTelemetry without making OTLP a required runtime dependency. This lets advanced users send Codex++ traces/logs/metrics to their own collector while keeping default installs private and offline.
+
+Evidence anchors:
+
+- OpenTelemetry JavaScript official docs describe generating and collecting traces, metrics, and logs in Node.js and browser contexts: https://opentelemetry.io/docs/languages/js/
+- The official OTLP spec defines the encoding, transport, and delivery mechanism for telemetry between sources, collectors, and backends: https://opentelemetry.io/docs/specs/otlp/
+- `packages/runtime/src/logging.ts:21-25` treats logging as best-effort and non-fatal, which should remain true for any exporter.
+- `SECURITY.md:20` says tweaks are local code and Codex++ does not automatically install replacement code, so telemetry export should be opt-in and explicit.
+
+Shippable slice:
+
+1. Keep the internal event schema independent from OpenTelemetry packages.
+2. Add a disabled-by-default exporter setting with `off`, `local-jsonl`, and `otlp-http` modes.
+3. For `local-jsonl`, write newline-delimited redacted events under `<user-data-dir>/log/events.jsonl`.
+4. For OTLP, require an explicit local endpoint and never export prompt content or raw tool arguments by default.
+
+### 9. App-server protocol catalog
+
+- Impact: medium
+- Effort: medium
+- Confidence: medium
+- Dependency: app-server protocol
+
+Add a debug-only catalog of app-server methods observed in the current session: request methods, notification methods, success/error counts, median latency, and sample redacted payload schemas. This helps future Codex++ features avoid guessing.
+
+Evidence anchors:
+
+- `packages/runtime/src/preload/app-server-bridge.ts:29-65` is the single request path for Codex++ initiated app-server calls.
+- `packages/runtime/src/preload/app-server-bridge.ts:94-118` is the single response dispatch path.
+- `packages/runtime/src/preload/app-server-bridge.ts:155-173` is the notification normalization path.
+
+Shippable slice:
+
+1. Count methods in memory for the current renderer session.
+2. Show only key names, primitive types, array lengths, and object depth-limited shapes.
+3. Add "copy schema sample" for research notes.
+4. Persist nothing unless the user toggles "record protocol evidence".
+
+### 10. Debug dashboard for tweak authors
+
+- Impact: medium
+- Effort: medium
+- Confidence: high
+- Dependency: Codex++ runtime seam
+
+Make tweak authoring observable: lifecycle events, start/stop duration, load failure stack, declared permissions, storage size, registered settings pages, app-server calls made through Codex++ helpers, and git API calls.
+
+Evidence anchors:
+
+- `packages/sdk/src/index.ts:42-66` defines manifest capabilities including `permissions`, `scope`, `mcp`, and `git.metadata`.
+- `packages/runtime/src/tweak-lifecycle.ts` owns reload, enable/disable, and lifecycle handling.
+- `packages/runtime/src/preload/tweak-host.ts:104-123` evaluates renderer tweak code.
+- `packages/runtime/src/main.ts:859-865` scopes main tweak logs by tweak id.
+
+Shippable slice:
+
+1. Emit `tweak.lifecycle` events around discovery, validation, start, stop, reload, and failure.
+2. Add per-tweak "debug" expansion in the Tweaks page.
+3. Show only local metadata by default; keep source code and user data out of the event stream.
+
+## 3. Wild ideas or moonshots
+
+### 11. Replayable agent session trace
+
+- Impact: moonshot
+- Effort: large
+- Confidence: low
+- Dependency: app-server protocol
+
+Record a privacy-preserving trace of an agent run that can be replayed as a timeline: prompt submission, model stream phases, tool calls, patches, command outputs summaries, review events, and final response. The valuable version is not a screen recording; it is a structured event replay where sensitive payloads can be redacted at capture time.
+
+Evidence anchors:
+
+- `packages/runtime/src/preload/app-server-bridge.ts:52-55` shows Codex++ can send app-server MCP requests with ids.
+- `packages/runtime/src/preload/app-server-bridge.ts:155-173` shows Codex++ can observe app-server notifications generically.
+- `docs/GIT_METADATA_SIDEBAR.md:18-20` notes that the public app-server thread model is coarse today, so richer run replay depends on protocol discovery rather than current documented guarantees.
+
+Shippable slice:
+
+1. Start with Codex++ owned events only.
+2. Add app-server notification capture behind a "record evidence" toggle.
+3. Export a single redacted JSON trace plus an HTML viewer.
+
+### 12. Patch/update black box recorder
+
+- Impact: high
+- Effort: large
+- Confidence: medium
+- Dependency: Codex++ runtime seam
+
+When repair or self-update fails, preserve the exact health snapshot, command phase, version, app hash, state diff, watcher state, and tail logs as a single local diagnostic bundle. This is especially important because Codex++ modifies app bundles, signatures, fuses, launch agents, and runtime assets.
+
+Evidence anchors:
+
+- `packages/installer/src/commands/repair.ts:38-147` has multiple early returns and repair paths for update mode, intact patch, runtime refresh, running app, and full reinstall.
+- `packages/installer/src/commands/self-update.ts:51-98` downloads source, installs dependencies, builds, swaps source roots, runs repair, and rolls back on failure.
+- `packages/installer/src/watcher.ts:55-100` creates the macOS launchd watcher with stdout/stderr pointed at a watcher log.
+
+Shippable slice:
+
+1. Emit phase markers during repair and self-update.
+2. On failure, write `<user-data-dir>/log/diagnostics/<timestamp>.json`.
+3. Add an in-app "Diagnostic bundles" list with copy/reveal actions.
+
+### 13. Health gates before dangerous actions
+
+- Impact: medium
+- Effort: medium
+- Confidence: medium
+- Dependency: Codex++ runtime seam
+
+Before actions like Codex update mode, self-update, repair, tweak reload, or enabling remote debug, show a small health gate that says which checks passed, which are risky, and whether the action will touch the app bundle, runtime dir, tweak dirs, launch agents, or network.
+
+Evidence anchors:
+
+- `packages/runtime/src/main.ts:53-67` exposes remote debugging through environment variables.
+- `packages/installer/src/commands/update-codex.ts:26-90` owns the official Codex update path.
+- `packages/installer/src/commands/repair.ts:133-147` can rerun install and reopen/prompt Codex.
+- `README.md:83-90` explains the Sparkle update constraint and `codexplusplus update-codex`.
+
+Shippable slice:
+
+1. Reuse patch health checks to classify action risk.
+2. Require explicit confirmation only for app-bundle or network-touching actions.
+3. Log every action decision as an observability event.
+
+## 4. Constraints and exact evidence
+
+- Codex++ lives outside the app bundle after initial patching, so observability should be implemented in the user-dir runtime first, not by source-patching Codex internals. Evidence: `docs/ARCHITECTURE.md:19-33`.
+- Renderer code is sandboxed and cannot use Node fs directly, so log/timeline reads need main-process IPC. Evidence: `packages/runtime/src/preload/index.ts:19-23` and `packages/runtime/src/preload/tweak-host.ts:8-12`.
+- Logging must stay best-effort and non-fatal. Evidence: `packages/runtime/src/logging.ts:21-25` and `packages/installer/src/logging.ts:15-21`.
+- Any observability export must be opt-in, redacted, and local-first because this project runs inside a modified Codex desktop app and can see sensitive prompts, tool outputs, project paths, and repository state.
+- App-server protocol work should preserve unknown messages rather than assuming stable names. Evidence: `packages/runtime/src/preload/app-server-bridge.ts:120-173` accepts several envelope shapes and generic notifications.
+- Patch health is multi-layered: app bundle, asar hash, plist hash, Electron fuse, code signature, runtime assets, state file, watcher service, update mode, and running app state. Evidence: `packages/installer/src/commands/status.ts:12-85`, `packages/installer/src/commands/doctor.ts:15-81`, and `packages/runtime/src/watcher-health.ts:38-90`.
+- Tweak observability cannot trust tweak code. Tweak source is evaluated from disk in renderer preload and should be treated as untrusted local code. Evidence: `packages/runtime/src/preload/tweak-host.ts:104-123` and `SECURITY.md:20`.
+
+## 5. Suggested next slice
+
+Build "Observability v0" as a runtime-owned page with no new required dependencies:
+
+1. `codexpp:get-log-tail`: main IPC handler returning redacted tails for allowlisted log files.
+2. `codexpp:get-runtime-health`: main IPC handler returning preload/tweak/reload/error snapshot.
+3. `app-server-bridge` renderer ring buffer: request, response, timeout, error, and notification events.
+4. Observability settings page: health strip, live logs, app-server timeline, error inbox.
+5. Tests: capped log tail parsing, redaction, runtime health snapshot updates, app-server ring buffer behavior.
+6. Manual proof: open Codex++ Config/Observability, force reload tweaks, run `/goal`, trigger an update check, and capture desktop plus narrow screenshots if the UI changes.
+
+Keep the first PR read-only and local-only. Defer OTLP export, persisted traces, diagnostic bundles, and deep tool-call decoding until the page proves useful with the telemetry Codex++ already owns.

--- a/research/agents/onboarding-settings.md
+++ b/research/agents/onboarding-settings.md
@@ -1,0 +1,248 @@
+# Onboarding, Settings, Config, MCP, Safe Mode, and Repair UX
+
+Owner: onboarding/settings product lane.
+
+Scope: product notes only. No code changes proposed here are implemented in this pass.
+
+## 1. Best Immediate Wins
+
+1. Ship a "Recovery Center" inside Settings -> Codex++ -> Config.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+   - Why: the repo already has the primitives, but they are split across CLI and UI. Config can read runtime config and watcher status through `codexpp:get-config` and `codexpp:get-watcher-health` (`packages/runtime/src/main.ts:453-472`), while CLI has `doctor`, `repair`, `status`, and `safe-mode` commands (`packages/installer/src/cli.ts:83-158`).
+   - Current UX gap: in-app Config shows auto-update, update checks, watcher health, uninstall command, and issue reporting (`packages/runtime/src/preload/settings-injector.ts:711-758`, `packages/runtime/src/preload/settings-injector.ts:991-1047`), but it cannot run a repair, run doctor, toggle safe mode, or produce a single "what is wrong and what will be changed" repair plan.
+   - Product slice:
+     - Add rows for `Safe Mode`, `Run Doctor`, `Repair Codex++`, `Open Logs`, and `Copy Diagnostics`.
+     - Use a dry-run style diagnostic first, then require explicit confirmation before repair touches the app bundle.
+     - Show "Codex must restart" states using the same terms as the repair command, which already postpones repair when Codex is still running on macOS (`packages/installer/src/commands/repair.ts:118-127`).
+   - Acceptance checks:
+     - Config page can tell a user whether the patch is intact, watcher is healthy, safe mode is on, and which exact command would be run.
+     - The repair path never silently mutates `~/.codex/config.toml` or tweak folders.
+
+2. Promote safe mode from CLI-only to a first-class in-app panic switch.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+   - Why: safe mode already exists in config and runtime behavior. `codexPlusPlus.safeMode` is part of persisted config (`packages/runtime/src/main.ts:69-78`), and `isTweakEnabled` returns false for every tweak when it is active (`packages/runtime/src/main.ts:125-131`). The CLI toggles this flag and touches a reload marker (`packages/installer/src/commands/safe-mode.ts:22-49`, `packages/installer/src/commands/safe-mode.ts:64-67`). `status` already reports it (`packages/installer/src/commands/status.ts:16-21`, `packages/installer/src/commands/status.ts:88-97`).
+   - Current UX gap: if a bad renderer tweak breaks Settings, the user may not know that `codex-plusplus safe-mode --on` exists. If Settings still opens, there is no switch there.
+   - Product slice:
+     - Show a safe-mode row at the top of Config with a warning tone when enabled.
+     - Add a keyboard/CLI fallback callout in troubleshooting docs, but keep the in-app switch as the primary path.
+     - When enabled, show disabled tweak rows with "suppressed by safe mode" rather than just their stored per-tweak toggle state.
+   - Acceptance checks:
+     - Safe mode disables main and renderer tweaks without deleting per-tweak flags.
+     - Turning safe mode off restores prior per-tweak enablement.
+
+3. Add a config.toml MCP preview and ownership boundary.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium-high.
+   - Dependency: native Codex seam plus Codex++ runtime seam.
+   - Why: Codex++ writes managed MCP server blocks into `~/.codex/config.toml` (`packages/runtime/src/main.ts:41-42`, `packages/runtime/src/main.ts:680-697`). The sync code preserves manual servers by stripping only its managed block and skipping names already configured by the user (`packages/runtime/src/mcp-sync.ts:45-87`, `packages/runtime/src/mcp-sync.ts:106-128`).
+   - Current UX gap: MCP sync is invisible unless logs are inspected. Users need to know which tweak owns each managed server, which manual server name caused a skip, and what file changed.
+   - Product slice:
+     - Add a "Managed MCP Servers" Config card listing server name, owning tweak, command, args, env key names only, and status: installed, skipped due to manual config, or invalid manifest.
+     - Add "View config diff" before writing future changes; never display env values by default.
+     - Keep the managed block markers as the user-facing contract: `# BEGIN CODEX++ MANAGED MCP SERVERS` and `# END CODEX++ MANAGED MCP SERVERS` (`packages/runtime/src/mcp-sync.ts:5-6`).
+   - Acceptance checks:
+     - Manual MCP servers outside the managed block are preserved.
+     - A name collision is reported as "manual server wins" instead of silently hiding the tweak server.
+
+4. Turn tweak discovery failures into actionable onboarding states.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+   - Why: discovery is strict and currently skips invalid tweak folders without surfacing reasons. It requires `manifest.json`, valid JSON, `id`, `name`, `version`, `githubRepo`, valid `githubRepo`, valid scope, and an entry file (`packages/runtime/src/tweak-discovery.ts:22-61`). The SDK validator can already produce structured errors and warnings (`packages/sdk/src/index.ts:96-187`, `packages/sdk/src/index.ts:216-244`).
+   - Current UX gap: Tweaks page only shows discovered tweaks or "No tweaks installed" (`packages/runtime/src/preload/settings-injector.ts:1177-1189`). A user with a broken tweak folder gets no explanation.
+   - Product slice:
+     - Introduce a discovery diagnostics list: valid tweaks, ignored folders, invalid manifests, missing entry, unsupported scope, missing `githubRepo`.
+     - Reuse SDK validation messages in runtime discovery so CLI and Settings explain the same failure.
+     - Add "Open tweak folder", "Copy manifest error", and "Validate tweak" actions.
+   - Acceptance checks:
+     - A bad manifest produces a visible reason in Tweaks.
+     - A missing entry file is shown as a repairable condition.
+
+5. Make first-run onboarding a state machine instead of README-only instructions.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam plus installer CLI.
+   - Why: README documents install steps and side effects (`README.md:46-58`), user directories (`README.md:147-163`), and day-to-day commands (`README.md:59-78`). The installer already performs ordered steps: locate Codex, preflight writable bundle, stage runtime, patch asar, update integrity, flip fuse, re-sign, install watcher, install default tweaks, and persist state (`packages/installer/src/commands/install.ts:36-156`).
+   - Current UX gap: once installed, the app does not show "what happened" or "what still needs attention" as a checklist.
+   - Product slice:
+     - Add a first-run "Setup complete / review" panel in Config: app path, Codex version/channel, watcher installed, runtime path, tweaks path, backup path, safe mode off, default tweaks installed/skipped.
+     - Preserve alpha honesty from README status (`README.md:5-8`) but translate it into concrete readiness checks.
+   - Acceptance checks:
+     - First successful launch shows a green setup checklist.
+     - Partial installs show the next command and exact failing check.
+
+## 2. Medium Bets
+
+1. Build a typed config service over `config.json` and `~/.codex/config.toml`.
+   - Impact: high.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: native Codex seam plus Codex++ runtime seam.
+   - Current state: Codex++ config is JSON in `<user-data-dir>/config.json` (`packages/installer/src/paths.ts:5-15`, `packages/runtime/src/main.ts:41`), while Codex MCP config is TOML in `~/.codex/config.toml` (`packages/runtime/src/main.ts:42`). Runtime reads/writes JSON directly (`packages/runtime/src/main.ts:102-123`) and MCP TOML via a managed text block (`packages/runtime/src/mcp-sync.ts:26-43`).
+   - Product bet:
+     - Create a single config service with typed reads, atomic writes, backups, validation, diffs, and audit log entries.
+     - Keep manual Codex TOML ownership explicit; Codex++ only owns its marked MCP block.
+     - Add "export diagnostics bundle" with redacted config shape, not secrets.
+   - Implementation note for later: this is where a TOML parser dependency should be evaluated instead of expanding ad-hoc string manipulation. Current runtime package dependencies are intentionally small (`packages/runtime/package.json:10-18`), so the dependency tradeoff should be explicit.
+
+2. Add a feature flag registry for Codex++ itself.
+   - Impact: medium-high.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: Codex++ runtime seam.
+   - Current state: the persisted config has booleans for `autoUpdate` and `safeMode`, but no generic feature flag registry (`packages/runtime/src/main.ts:69-78`). Config UI exposes only auto-update today (`packages/runtime/src/preload/settings-injector.ts:755-781`).
+   - Product bet:
+     - Introduce `codexPlusPlus.features` as typed feature flags with metadata: title, risk tier, default, owner, kill-switch behavior, and visibility.
+     - Use it for experimental product surfaces: MCP preview, repair actions, tweak marketplace/catalog, config editor, git sidebar, goal command, and remote debugging affordances.
+     - Add per-feature safe-mode overrides so dangerous experimental features can be disabled without suppressing every tweak.
+
+3. Build tweak discovery as "tweak inbox + catalog" instead of a raw folder list.
+   - Impact: medium-high.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: external service optional, Codex++ runtime seam required.
+   - Current state: default tweaks are installed from GitHub releases and local tweak folders are never overwritten (`docs/ARCHITECTURE.md:43-45`). Installed tweak rows already display version, author, repo, homepage, tags, update badge, review-release action, and enable toggle (`packages/runtime/src/preload/settings-injector.ts:1245-1363`).
+   - Product bet:
+     - Add a local catalog JSON that lists recommended tweaks, install source, permissions, MCP exposure, and trust tier.
+     - Stage downloads into a review inbox; require explicit install after showing manifest, release notes, permissions, and file list.
+     - Keep update checks advisory, consistent with security policy that Codex++ never auto-installs tweak code (`SECURITY.md:20-26`, `docs/ARCHITECTURE.md:37-42`).
+
+4. Add a "Repair Timeline" and notification history.
+   - Impact: medium.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: installer CLI plus runtime UI.
+   - Current state: watcher health can inspect launchd/systemd/scheduled-task state and recent watcher log tail (`packages/runtime/src/watcher-health.ts:38-89`, `packages/runtime/src/watcher-health.ts:92-207`). Repair has several branches: update mode active, patch intact, runtime update, forced install, postponed while app is running (`packages/installer/src/commands/repair.ts:49-147`).
+   - Product bet:
+     - Persist a compact event log: install, repair, watcher refresh, Codex update detected, runtime update skipped due to auto-update off, safe mode toggled, MCP block changed.
+     - Show "last repair reason" and "next repair action" in Config.
+
+5. Make settings injection self-diagnosing.
+   - Impact: medium.
+   - Effort: medium.
+   - Confidence: medium.
+   - Dependency: native Codex seam.
+   - Current state: settings injection is DOM-heuristic based and looks for Codex's routed settings sidebar by known labels, not stable test IDs (`packages/runtime/src/preload/settings-injector.ts:1-21`, `packages/runtime/src/preload/settings-injector.ts:298-371`). The architecture doc still describes an older modal/dialog/tablist model (`docs/ARCHITECTURE.md:72-75`), so docs and implementation drift have already happened.
+   - Product bet:
+     - Add a hidden "Settings injector diagnostics" dump in Config or logs: sidebar labels found, content area found, active page state, last injection failure.
+     - Update architecture docs alongside the UI so future product work does not target stale Radix dialog assumptions.
+
+## 3. Wild Ideas / Moonshots
+
+1. "Undoable Desktop Surgery" mode.
+   - Impact: moonshot.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: installer CLI, app bundle, runtime UI.
+   - Idea: every app-bundle operation becomes a reversible transaction shown in UI: planned files, hashes before/after, signature state, backup path, rollback command. This would make app patching feel less like a black box.
+   - Anchor: install already records original and patched hashes plus app metadata in state (`packages/installer/src/commands/install.ts:134-148`), and status compares current asar/plist/fuse state (`packages/installer/src/commands/status.ts:59-85`).
+
+2. MCP permission firewall.
+   - Impact: moonshot.
+   - Effort: large.
+   - Confidence: low-medium.
+   - Dependency: native Codex seam plus external MCP process supervision.
+   - Idea: instead of only writing MCP commands to `config.toml`, Codex++ could launch managed MCP servers through a supervisor that enforces env redaction, cwd restrictions, process lifetime, logging, and per-tool allow/deny policy.
+   - Anchor: current manifest supports a single `mcp` object with command, args, and env (`packages/sdk/src/index.ts:44-62`), and sync writes those values into TOML (`packages/runtime/src/mcp-sync.ts:141-155`).
+
+3. Tweak marketplace with verified provenance.
+   - Impact: moonshot.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: external service optional.
+   - Idea: signed tweak manifests, release attestation, maintainer identity, permissions diff, and user review gates. Codex++ should remain local-first, but the catalog could rank "trusted enough to inspect" rather than "trusted to auto-run."
+   - Anchor: current security stance says tweaks are local code, untrusted until reviewed, and updates are advisory (`SECURITY.md:20-26`).
+
+4. Guided repair chat inside Settings.
+   - Impact: moonshot.
+   - Effort: research.
+   - Confidence: low-medium.
+   - Dependency: native Codex seam plus local logs.
+   - Idea: an in-app repair assistant that reads bounded diagnostics, explains failure states, and proposes exact repair commands without sending raw logs or secrets by default.
+   - Boundary: keep this metadata-only unless user explicitly attaches logs. Logs and config may contain paths, usernames, repo names, or env shape.
+
+## 4. Constraints And Exact Evidence
+
+1. Config and state are split.
+   - `config.json` stores user preferences and per-tweak flags (`packages/runtime/src/main.ts:69-78`, `packages/runtime/src/main.ts:102-137`).
+   - `state.json` stores installer records (`packages/installer/src/paths.ts:12-15`, `docs/ARCHITECTURE.md:31-33`).
+   - `~/.codex/config.toml` is touched only for MCP sync (`packages/runtime/src/main.ts:41-42`, `packages/runtime/src/main.ts:680-697`).
+
+2. Tweak loading has separate main and renderer paths.
+   - Main discovers tweaks and starts main-scope tweaks (`packages/runtime/src/main.ts:632-678`).
+   - Renderer host asks main for tweak list and user paths, then loads renderer-scope tweaks (`packages/runtime/src/preload/tweak-host.ts:53-85`).
+   - Runtime reload stops main tweaks, clears module cache, reloads, and broadcasts (`packages/runtime/src/tweak-lifecycle.ts:19-36`, `packages/runtime/src/main.ts:591-610`).
+
+3. MCP sync is already conservative but not visible.
+   - Managed block markers are explicit (`packages/runtime/src/mcp-sync.ts:5-6`).
+   - Manual server names are detected after stripping managed content (`packages/runtime/src/mcp-sync.ts:45-68`, `packages/runtime/src/mcp-sync.ts:89-114`).
+   - Relative commands/args are resolved against tweak directories (`packages/runtime/src/mcp-sync.ts:141-170`).
+
+4. Safe mode is effective but discoverability is weak.
+   - Safe mode is a persisted config flag (`packages/runtime/src/main.ts:69-78`).
+   - Runtime suppresses all tweak enablement when safe mode is true (`packages/runtime/src/main.ts:125-131`).
+   - CLI supports `safe-mode --on`, `--off`, and `--status` (`packages/installer/src/cli.ts:152-158`, `packages/installer/src/commands/safe-mode.ts:22-49`).
+
+5. Repair UX already has robust backend concepts.
+   - `doctor` checks user dir, install state, app presence, asar hash, signature, and key directories (`packages/installer/src/commands/doctor.ts:15-82`).
+   - `repair` preserves user config and tweaks, refreshes watcher, waits for app updates to settle, respects auto-update, and can postpone when Codex is running (`packages/installer/src/commands/repair.ts:30-147`, `packages/installer/src/commands/repair.ts:167-177`, `packages/installer/src/commands/repair.ts:179-220`).
+   - Watcher health already summarizes state for in-app display (`packages/runtime/src/watcher-health.ts:38-89`, `packages/runtime/src/watcher-health.ts:209-233`).
+
+6. Security posture should stay local-first and review-first.
+   - Default tweak updates are advisory, not automatic (`README.md:139-145`, `docs/ARCHITECTURE.md:37-42`).
+   - Security docs explicitly warn that renderer and main-process tweaks are local code with real capabilities (`SECURITY.md:20-26`).
+   - Renderer file access is sandboxed through IPC and per-tweak data dirs (`packages/runtime/src/main.ts:535-552`, `packages/runtime/src/preload/tweak-host.ts:248-258`).
+
+7. Documentation drift is a product risk.
+   - Current settings injector comments describe a routed settings page with sidebar label matching (`packages/runtime/src/preload/settings-injector.ts:1-21`).
+   - Architecture docs still describe Radix dialog/tablist injection (`docs/ARCHITECTURE.md:72-75`).
+   - Any onboarding or Settings roadmap should include a docs correction slice before another agent builds against stale DOM assumptions.
+
+## 5. Suggested Next Slice
+
+1. Implement Recovery Center v1 behind a local Codex++ feature flag.
+   - Write set for a future worker:
+     - `packages/runtime/src/main.ts`
+     - `packages/runtime/src/preload/settings-injector.ts`
+     - `packages/runtime/src/watcher-health.ts` if diagnostics need richer fields
+     - focused tests under `packages/runtime/test/`
+   - Keep installer command behavior unchanged in v1; UI can copy commands or call read-only diagnostics first.
+   - Add UI rows:
+     - Safe Mode toggle.
+     - Doctor summary with "Copy Diagnostics".
+     - Watcher summary with current detail rows.
+     - Repair CTA that starts as "Copy repair command" unless/until a safe IPC command runner is designed.
+     - Managed MCP summary with skipped/manual collisions.
+   - Acceptance checks:
+     - `npm run test --workspace @codex-plusplus/runtime`
+     - targeted tests for safe-mode config read/write and MCP summary derivation
+     - manual screenshot of Config page with safe mode off/on and watcher status
+
+2. Then implement Tweak Diagnostics v1.
+   - Write set for a future worker:
+     - `packages/runtime/src/tweak-discovery.ts`
+     - `packages/sdk/src/index.ts` only if validator output needs extra issue codes
+     - `packages/runtime/src/preload/settings-injector.ts`
+     - tests under `packages/runtime/test/tweak-discovery.test.ts` and `packages/sdk/test/manifest-validation.test.ts`
+   - Acceptance checks:
+     - invalid JSON, missing `githubRepo`, bad scope, missing entry, and valid tweak fixtures all render distinct states.
+     - Existing valid tweak behavior remains unchanged.
+
+3. Follow with Config Service v1 only after the UI proves the shape.
+   - Write set for a future worker:
+     - new runtime config module
+     - new installer shared config helper if CLI and runtime should share it
+     - MCP sync tests that prove manual TOML content is preserved
+   - Acceptance checks:
+     - config writes are atomic.
+     - backups are created before touching `~/.codex/config.toml`.
+     - env values are never rendered in diagnostics unless explicitly revealed.

--- a/research/agents/runtime-architecture.md
+++ b/research/agents/runtime-architecture.md
@@ -1,0 +1,463 @@
+# Runtime Architecture And Extension Contracts
+
+Scope: ordered architecture/product notes for Codex++ extension contracts,
+missing abstractions, capability registry shape, SDK/API opportunities, and
+platform risks. This is based on the current working tree, including in-flight
+runtime changes under `packages/runtime` and `packages/sdk`.
+
+## 1. Current Architecture Facts
+
+1. Codex++ is an Electron app patch plus user-dir runtime, not a rebuilt Codex
+   distribution.
+   - The product README says the installer locates Codex.app, backs it up,
+     patches `app.asar`, recomputes `ElectronAsarIntegrity`, flips the embedded
+     asar integrity fuse, ad-hoc signs the app on macOS, and installs a watcher
+     for repair after Codex updates. Evidence: `README.md:46-58`.
+   - The architecture doc shows `app.asar`'s `package.json#main` pointing to
+     `codex-plusplus-loader.cjs`, which then loads `<user-data-dir>/runtime`.
+     Evidence: `docs/ARCHITECTURE.md:3-35`.
+
+2. The runtime has two extension execution planes: main process and renderer
+   preload.
+   - Main boot validates required env vars, sets user/runtime paths, creates
+     tweak/log directories, and imports discovery, lifecycle, MCP sync, storage,
+     watcher health, and git metadata modules. Evidence:
+     `packages/runtime/src/main.ts:10-27`, `packages/runtime/src/main.ts:28-51`.
+   - Renderer boot installs the React hook, starts the built-in goal feature,
+     starts settings injection, starts the renderer tweak host, mounts the
+     manager, and subscribes to hot reload. Evidence:
+     `packages/runtime/src/preload/index.ts:43-57`,
+     `packages/runtime/src/preload/index.ts:67-103`.
+
+3. Tweak discovery is folder-and-manifest based.
+   - Discovery scans `<userRoot>/tweaks`, requires `manifest.json`, validates
+     required fields, resolves `manifest.main` or `index.js`/`index.cjs`/
+     `index.mjs`, and silently skips invalid entries. Evidence:
+     `packages/runtime/src/tweak-discovery.ts:22-41`,
+     `packages/runtime/src/tweak-discovery.ts:44-61`.
+   - The public manifest contract lives in SDK types and currently covers id,
+     name, version, `githubRepo`, metadata, scope, entry, MCP server, and
+     permissions. Evidence: `packages/sdk/src/index.ts:9-51`.
+
+4. Tweak lifecycle is reload-oriented, not per-capability or per-resource.
+   - Main reload stops all main tweaks, clears tweak module cache, reloads all
+     main tweaks, then broadcasts a renderer reload. Evidence:
+     `packages/runtime/src/tweak-lifecycle.ts:19-25`,
+     `packages/runtime/test/tweak-lifecycle.test.ts:20-32`.
+   - The filesystem watcher debounces changes under the tweak directory and
+     delegates to that same reload sequence. Evidence:
+     `packages/runtime/src/main.ts:598-628`.
+
+5. Renderer tweaks are evaluated from source strings in preload.
+   - The runtime cannot require arbitrary tweak files from sandboxed renderers,
+     so main reads the tweak source and preload evaluates it with `new Function`.
+     Evidence: `packages/runtime/src/preload/tweak-host.ts:1-13`,
+     `packages/runtime/src/preload/tweak-host.ts:104-130`.
+   - This means renderer tweak dependencies must be bundled ahead of time, and
+     runtime isolation is a policy problem, not just a package format problem.
+
+6. Settings UI is an injected DOM surface with weak native anchors.
+   - The settings injector explicitly documents that Codex settings are a routed
+     page with no stable `role`, `aria-label`, or `data-testid` hooks, so it
+     identifies the sidebar by text/content heuristics. Evidence:
+     `packages/runtime/src/preload/settings-injector.ts:1-21`.
+   - Registered sections and pages are tracked in renderer state and remounted
+     into Codex++ settings surfaces. Evidence:
+     `packages/runtime/src/preload/settings-injector.ts:106-129`,
+     `packages/runtime/src/preload/settings-injector.ts:224-288`.
+
+7. MCP, git metadata, and goals are already emerging as platform capabilities.
+   - Enabled tweaks with manifest `mcp` can sync managed MCP server entries into
+     `~/.codex/config.toml` while preserving user-managed servers. Evidence:
+     `packages/runtime/src/main.ts:680-698`,
+     `packages/runtime/src/mcp-sync.ts:26-43`,
+     `packages/runtime/src/mcp-sync.ts:45-80`.
+   - Git metadata is a main-process provider exposed through renderer IPC when
+     the manifest declares `git.metadata`. Evidence:
+     `packages/runtime/src/git-metadata.ts:154-249`,
+     `packages/runtime/src/preload/tweak-host.ts:160-218`.
+   - `/goal` is a built-in preload feature using a private app-server bridge to
+     `thread/goal/*` calls and notifications. Evidence:
+     `packages/runtime/src/preload/app-server-bridge.ts:29-66`,
+     `packages/runtime/src/preload/app-server-bridge.ts:86-174`,
+     `packages/runtime/src/preload/goal-feature.ts:36-78`,
+     `packages/runtime/src/preload/goal-feature.ts:344-360`.
+
+## 2. Extension Contract Gaps To Close First
+
+1. Add one canonical extension descriptor and validation path.
+   - Current state: SDK validation and runtime discovery both validate
+     manifests, but discovery reimplements a smaller validator and does not call
+     `validateTweakManifest`. Evidence: `packages/sdk/src/index.ts:96-188`,
+     `packages/runtime/src/tweak-discovery.ts:44-49`.
+   - Product risk: a tweak can pass one path and fail or silently disappear in
+     another. Silent skipping is acceptable for malformed folders, but authors
+     need a reasoned diagnostic model.
+   - Proposed contract: `ExtensionDescriptor = { manifest, dir, entry,
+     validation, runtimeCompatibility, capabilities }`, produced once by shared
+     SDK/runtime code and consumed by manager, lifecycle, MCP sync, CLI validate,
+     and docs.
+   - Priority: high. Effort: medium. Confidence: high. Dependency:
+     Codex++ runtime seam.
+
+2. Enforce `minRuntime` and version compatibility.
+   - Current state: `minRuntime` exists in the manifest type and docs, but the
+     runtime discovery and loader do not enforce it. Evidence:
+     `packages/sdk/src/index.ts:38-43`,
+     `docs/WRITING-TWEAKS.md:59-62`,
+     `packages/runtime/src/tweak-discovery.ts:44-49`.
+   - Product risk: incompatible tweaks can fail at `start()` time, where the
+     failure is harder to explain and may leave partial UI/IPC state behind.
+   - Proposed contract: discovery should mark incompatible tweaks as discovered
+     but disabled with a precise reason, so Settings can show "requires runtime
+     >= X" rather than "missing entry" or nothing.
+   - Priority: high. Effort: small. Confidence: high. Dependency:
+     Codex++ runtime seam.
+
+3. Make permission declarations executable policy, not only metadata.
+   - Current state: SDK validates known permissions. Evidence:
+     `packages/sdk/src/index.ts:64-83`,
+     `packages/sdk/src/index.ts:169-180`,
+     `packages/sdk/test/manifest-validation.test.ts:73-88`.
+   - Current enforcement is partial: renderer `api.git` is attached only when
+     `git.metadata` is declared, but `settings`, `ipc`, and `fs` are always
+     present in renderer API, and main-scope tweaks receive `ipc`, `fs`, `git`,
+     and `codex` without visible per-permission gating. Evidence:
+     `packages/runtime/src/preload/tweak-host.ts:160-218`,
+     `packages/runtime/src/main.ts:653-667`.
+   - Product risk: permission review cards and manifest metadata will overstate
+     real enforcement. This matters before a public tweak ecosystem forms.
+   - Proposed contract: every API factory should require a capability decision
+     object: `{ granted, reason, source, risk }`. Missing permissions should
+     produce absent APIs plus manager warnings.
+   - Priority: high. Effort: medium. Confidence: high. Dependency:
+     Codex++ runtime seam.
+
+4. Split extension identity from process lifecycle.
+   - Current state: `scope` is `"renderer" | "main" | "both"`, and `"both"`
+     means `start(api)` is called once per process. Evidence:
+     `packages/sdk/src/index.ts:53-55`,
+     `packages/sdk/src/index.ts:257-284`,
+     `docs/WRITING-TWEAKS.md:71-76`.
+   - Product risk: cross-process extensions have to hand-roll coordination over
+     ad hoc IPC. The runtime cannot tell which half owns durable state,
+     background tasks, settings pages, or MCP tools.
+   - Proposed contract: add process components under one extension id:
+     `components: { renderer?: RendererEntrypoint, main?: MainEntrypoint,
+     mcp?: McpEntrypoint }`, with explicit dependencies and teardown ordering.
+   - Priority: medium-high. Effort: large. Confidence: medium. Dependency:
+     Codex++ runtime seam.
+
+5. Replace untyped string IPC with a scoped contract registry.
+   - Current state: tweak IPC namespaces channels by id, but channel payloads
+     and handlers are untyped. Evidence:
+     `packages/sdk/src/index.ts:370-377`,
+     `packages/runtime/src/preload/tweak-host.ts:206-215`,
+     `packages/runtime/src/main.ts:868-885`.
+   - Product risk: API drift appears only at runtime, and one half of a `"both"`
+     tweak can register stale handlers after reload if teardown is incomplete.
+   - Proposed contract: SDK helper for `defineIpcContract({ methods, events })`
+     with runtime validation, duplicate handler protection, and unload cleanup.
+   - Priority: medium. Effort: medium. Confidence: high. Dependency:
+     Codex++ runtime seam.
+
+6. Make storage semantics consistent across processes.
+   - Current state: main storage is disk-backed with debounced atomic writes,
+     while renderer storage uses `localStorage`. Evidence:
+     `packages/runtime/src/storage.ts:1-7`,
+     `packages/runtime/src/storage.ts:27-87`,
+     `packages/runtime/src/preload/tweak-host.ts:221-245`.
+   - Documentation drift: current docs still say main storage is in-memory and
+     will move to disk later. Evidence: `docs/WRITING-TWEAKS.md:103-106`.
+   - Product risk: users and tweak authors cannot reason about backup, sync,
+     deletion, corruption, and privacy if renderer/main data stores differ.
+   - Proposed contract: one `api.storage` implementation backed by main process
+     for both renderer and main, with optional `sessionStorage` or `uiState`
+     namespaces when renderer-local state is intentional.
+   - Priority: medium-high. Effort: medium. Confidence: high. Dependency:
+     Codex++ runtime seam.
+
+## 3. Capability Registry Shape
+
+1. Registry goal.
+   - Build a central registry that maps declarative manifest permissions to
+     concrete runtime APIs, settings UI copy, validation errors, process
+     availability, and platform risk.
+   - This should become the single source for SDK types, CLI validation,
+     Settings permission review, runtime API factories, and release notes.
+
+2. Minimum registry fields.
+   - `id`: stable capability id, for example `settings.page`, `ipc.scoped`,
+     `fs.tweakData`, `git.metadata`, `codex.window`, `codex.view`,
+     `mcp.server`, `appServer.goal`, `network.githubReleases`.
+   - `permission`: manifest permission string if user-authorized, or `internal`
+     for built-in runtime features.
+   - `processes`: `renderer`, `main`, or both.
+   - `apiFactory`: function that builds the API or returns a denied reason.
+   - `risk`: short user-facing description of what the capability can observe
+     or mutate.
+   - `proof`: diagnostic status for manager UI, for example available,
+     unavailable on this Codex build, denied by manifest, denied by safe mode,
+     or failed to initialize.
+   - `tests`: required test anchors for validation.
+
+3. Initial registry rows.
+   - `settings.page`: renderer; permission `settings`; backs
+     `api.settings.register` and `api.settings.registerPage`. Evidence:
+     `packages/sdk/src/index.ts:300-341`,
+     `packages/runtime/src/preload/tweak-host.ts:172-176`.
+   - `ipc.scoped`: both; permission `ipc`; backs namespaced tweak channels.
+     Evidence: `packages/sdk/src/index.ts:370-377`,
+     `packages/runtime/src/preload/tweak-host.ts:206-215`,
+     `packages/runtime/src/main.ts:868-885`.
+   - `fs.tweakData`: both; permission `filesystem`; backs per-tweak data
+     directory only. Evidence: `packages/sdk/src/index.ts:379-385`,
+     `packages/runtime/src/main.ts:535-552`,
+     `packages/runtime/src/main.ts:888-905`.
+   - `git.metadata`: both eventually, renderer-gated now; permission
+     `git.metadata`; backs repository resolution, status, diff summary, and
+     worktree metadata. Evidence: `packages/sdk/src/index.ts:387-392`,
+     `packages/runtime/src/git-metadata.ts:130-135`,
+     `packages/runtime/src/preload/tweak-host.ts:261-271`.
+   - `codex.window`: main; permission should map to `codex.windows`; backs
+     Codex window creation through native private services. Evidence:
+     `packages/sdk/src/index.ts:64-83`,
+     `packages/runtime/src/main.ts:937-988`.
+   - `codex.view`: main; permission should map to `codex.views`; backs
+     embedded `BrowserView` creation and registration. Evidence:
+     `packages/runtime/src/main.ts:907-935`,
+     `packages/runtime/src/main.ts:991-1037`.
+   - `mcp.server`: main/internal plus manifest declaration; backs managed MCP
+     config generation from `manifest.mcp`. Evidence:
+     `packages/sdk/src/index.ts:45-51`,
+     `packages/runtime/src/mcp-sync.ts:56-80`.
+   - `appServer.goal`: internal for now; backs the built-in `/goal` feature.
+     Evidence: `packages/runtime/src/preload/app-server-bridge.ts:29-66`,
+     `packages/runtime/src/preload/goal-feature.ts:187-231`.
+
+4. UI consequence.
+   - The Tweak Manager should not only show "loaded" or "missing entry".
+     Current minimal manager rendering lists name, version, description, and
+     entry state. Evidence: `packages/runtime/src/preload/manager.ts:12-75`.
+   - It should show capability rows: requested, granted, unavailable, and
+     why. That makes the extension system reviewable before installs become
+     one-click.
+
+## 4. SDK/API Opportunities
+
+1. Add `defineTweak` and make docs true.
+   - Current docs import `defineTweak`, but SDK does not export it in the
+     inspected source. Evidence: `docs/WRITING-TWEAKS.md:159-176`,
+     `packages/sdk/src/index.ts:252-284`.
+   - Ship a zero-runtime helper first:
+     `defineTweak<T extends Tweak>(tweak: T): T`.
+   - Priority: high. Effort: small. Confidence: high.
+
+2. Provide a buildable TypeScript tweak starter.
+   - Current `create-tweak` writes CommonJS `index.js`, a private package, and
+     SDK `^0.1.3` dependency. Evidence:
+     `packages/installer/src/commands/create-tweak.ts:55-68`,
+     `packages/installer/src/commands/create-tweak.ts:87-151`.
+   - Product opportunity: `codexplusplus create-tweak --template ts` should
+     produce `src/index.ts`, `tsconfig.json`, a bundler script, `validate`, and
+     a generated manifest. This directly removes the gap created by preload
+     source evaluation and bundled-dependency requirements.
+   - Priority: high. Effort: small-medium. Confidence: high.
+
+3. Export typed platform clients instead of raw optional bags.
+   - Current `TweakApi` exposes optional `settings`, `react`, `codex`, and `git`
+     based on process/capability. Evidence: `packages/sdk/src/index.ts:262-284`.
+   - Opportunity: add process-specific SDK entrypoints:
+     `defineRendererTweak`, `defineMainTweak`, `defineDualTweak`. These helpers
+     can narrow available APIs, require declared capabilities, and reduce
+     runtime "undefined API" failures.
+   - Priority: medium-high. Effort: medium. Confidence: high.
+
+4. Promote `app-server` bridge into a guarded internal API, then decide whether
+   to expose it.
+   - Current bridge is functional but private and message-shape tolerant.
+     Evidence: `packages/runtime/src/preload/app-server-bridge.ts:29-66`,
+     `packages/runtime/src/preload/app-server-bridge.ts:120-174`.
+   - Product opportunity: start with internal typed clients for `thread.goal`.
+     If stable across Codex Desktop builds, expose read-only thread context and
+     goal APIs to tweaks behind a new permission such as `codex.threadMetadata`.
+   - Priority: medium. Effort: medium. Confidence: medium.
+
+5. Add watch/event APIs for metadata surfaces.
+   - Current git metadata is request/response only. Evidence:
+     `packages/sdk/src/index.ts:387-392`,
+     `packages/runtime/src/git-metadata.ts:130-135`.
+   - Existing research asks for event-first, poll-backed sidebar refresh.
+     Evidence: `docs/GIT_METADATA_SIDEBAR.md:76-88`,
+     `research/agents/git-sidebar.md:183-207`.
+   - Product opportunity: `api.git.watchStatus(root, callback)` or runtime
+     event hooks would prevent every sidebar/page tweak from inventing its own
+     polling policy.
+   - Priority: medium. Effort: medium-large. Confidence: medium.
+
+6. Add platform component APIs for Settings UI.
+   - Current settings rendering is imperative DOM. Evidence:
+     `packages/sdk/src/index.ts:319-341`,
+     `docs/WRITING-TWEAKS.md:77-91`.
+   - Product opportunity: a tiny SDK component kit for cards, rows, toggles,
+     badges, empty/error states, permission rows, and links would keep tweaks
+     visually consistent without exposing Codex's React runtime.
+   - Priority: medium. Effort: medium. Confidence: high.
+
+7. Turn MCP-backed tweaks into an install/status product.
+   - Current sync creates managed config blocks and skips conflicting
+     user-managed server names. Evidence:
+     `packages/runtime/src/mcp-sync.ts:45-80`,
+     `packages/runtime/test/mcp-sync.test.ts:47-65`,
+     `packages/runtime/test/mcp-sync.test.ts:68-133`.
+   - Product opportunity: Settings should show which MCP servers an extension
+     declares, whether each was synced, skipped, or invalid, and the exact
+     generated server name. This is a high-leverage bridge from "DOM tweaks" to
+     real Codex tool extensions.
+   - Priority: high. Effort: small-medium. Confidence: high.
+
+## 5. Platform Risks
+
+1. Native Codex UI selectors are brittle.
+   - Settings injection depends on current text and DOM shape, not stable
+     first-party extension points. Evidence:
+     `packages/runtime/src/preload/settings-injector.ts:1-21`,
+     `packages/runtime/src/preload/settings-injector.ts:1666-1695`.
+   - Risk response: every injected surface should have an availability probe,
+     a visible fallback in manager/doctor, and screenshot-based verification
+     after Codex Desktop updates.
+
+2. Preload execution is powerful and currently trust-based.
+   - Renderer tweaks are source strings evaluated with `new Function` in the
+     preload context. Evidence:
+     `packages/runtime/src/preload/tweak-host.ts:104-130`.
+   - Risk response: before broad distribution, introduce permission-enforced
+     API construction, extension trust/source metadata, and at least a
+     "review local code before enabling" flow. Do not imply this is a browser
+     sandbox.
+
+3. Private app-server protocol can drift.
+   - The bridge accepts multiple response/notification shapes, which is useful
+     but proves this is not a formal public API. Evidence:
+     `packages/runtime/src/preload/app-server-bridge.ts:120-174`.
+   - Risk response: build feature probes per method, fail closed, and keep
+     app-server integrations internal until several Codex Desktop versions are
+     validated.
+
+4. Private window services can disappear or change.
+   - `makeCodexApi()` depends on a global `__codexpp_window_services__` object
+     and native service methods. Evidence:
+     `packages/runtime/src/main.ts:907-948`,
+     `packages/runtime/src/main.ts:1046-1049`.
+   - Risk response: expose `codex.window`/`codex.view` as optional
+     capabilities with detailed unavailable reasons instead of assuming a
+     reinstall fixes every failure.
+
+5. Main-process APIs need path containment hardening everywhere.
+   - Renderer source and asset reads have containment checks. Evidence:
+     `packages/runtime/src/main.ts:474-483`,
+     `packages/runtime/src/main.ts:485-524`.
+   - Renderer `tweak-fs` rejects ids and `..`, but main `makeMainFs` joins
+     paths directly under the data dir without the same containment guard.
+     Evidence: `packages/runtime/src/main.ts:535-552`,
+     `packages/runtime/src/main.ts:888-905`.
+   - Risk response: centralize `resolveTweakDataPath(id, relPath)` and use it
+     for main and renderer filesystem APIs.
+
+6. Docs and generated assets can drift from source.
+   - Current docs say main storage is in-memory even though source shows
+     disk-backed storage. Evidence: `docs/WRITING-TWEAKS.md:103-106`,
+     `packages/runtime/src/storage.ts:1-7`.
+   - Tests already compare source and bundled runtime for reload behavior,
+     showing this repo has prior drift concerns between TS source and bundled
+     installer assets. Evidence:
+     `packages/runtime/test/main-toggle-reload.test.ts:6-16`,
+     `packages/runtime/test/main-toggle-reload.test.ts:24-98`.
+   - Risk response: add contract tests for public docs snippets, SDK exports,
+     and generated runtime assets, or make docs generated from SDK metadata.
+
+7. Release/update trust is advisory today.
+   - Tweak updates are checked against GitHub Releases but not installed
+     automatically. Evidence: `docs/WRITING-TWEAKS.md:63-68`,
+     `packages/runtime/src/main.ts:757-788`,
+     `packages/runtime/src/main.ts:790-828`.
+   - Risk response: keep auto-install out of scope until there is signed
+     package metadata, ownership continuity checks, hash pinning, and rollback.
+
+## 6. Ordered Product Plan
+
+1. Capability registry plus permission review card.
+   - Behavior: Settings shows every requested capability, grant status, risk
+     text, and unavailable reasons.
+   - Why first: this turns the extension system from "trust this folder" into a
+     reviewable platform while reusing existing manifest permissions.
+   - Acceptance: a tweak with `git.metadata`, `mcp`, `settings`, `ipc`, and
+     missing `minRuntime` renders a precise capability table; disabling a
+     permission removes the API from the relevant process.
+   - Impact: high. Effort: medium. Confidence: high.
+
+2. Canonical descriptor and compatibility diagnostics.
+   - Behavior: discovery returns valid, invalid, disabled, incompatible, and
+     missing-entry tweaks with structured reasons.
+   - Why second: every higher-level UI, CLI, and SDK workflow depends on not
+     silently losing extensions.
+   - Acceptance: `validate-tweak`, runtime discovery, and manager show the same
+     errors for malformed permissions, MCP config, entry path, and min runtime.
+   - Impact: high. Effort: medium. Confidence: high.
+
+3. SDK ergonomics release.
+   - Behavior: export `defineTweak`, process-specific helpers, typed IPC
+     contracts, and a buildable TypeScript starter.
+   - Why third: once contracts are real, make the happy path hard to misuse.
+   - Acceptance: `codexplusplus create-tweak --template ts` creates a tweak
+     that builds, validates, loads in renderer/main as selected, and uses SDK
+     types without docs-only imports.
+   - Impact: high. Effort: medium. Confidence: high.
+
+4. MCP extension status.
+   - Behavior: manager shows declared MCP servers, generated names, sync state,
+     conflict/skipped state, and config path.
+   - Why fourth: MCP is the clearest bridge from tweak UI to Codex tool
+     capability, and the underlying sync is already implemented.
+   - Acceptance: tests cover synced, skipped, removed, malformed, relative
+     server script, and no-MCP cases; Settings mirrors those states.
+   - Impact: high. Effort: small-medium. Confidence: high.
+
+5. Internal app-server client boundary.
+   - Behavior: built-in goals and future thread/project features use a typed
+     app-server client with feature probes and fail-closed states.
+   - Why fifth: `/goal` is valuable but private protocol drift is a platform
+     risk. Stabilize the internal boundary before exposing it to third-party
+     tweaks.
+   - Acceptance: current goal flows work on the known app-server build, and
+     unsupported builds produce one visible unsupported state without repeated
+     errors.
+   - Impact: high. Effort: medium. Confidence: medium.
+
+6. Read-only project metadata platform.
+   - Behavior: first-party or default tweak can render project snapshot,
+     sidebar badges, diff footer, and worktree state from `api.git`.
+   - Why sixth: git metadata is already intentionally read-only and matches the
+     user's high-value workflow, but should depend on the capability registry
+     and event/watch policy to avoid N independent polling loops.
+   - Acceptance: clean repo, dirty repo, initial commit, detached HEAD, bare
+     repo, non-repo path, linked worktree, and truncated-output states are all
+     visibly distinct.
+   - Impact: high. Effort: medium. Confidence: high.
+
+## 7. Suggested Next Slice
+
+Implement the registry/descriptor foundation before adding new user-facing
+capabilities:
+
+1. Introduce `packages/sdk/src/capabilities.ts` or equivalent registry source.
+2. Replace duplicated manifest validation in runtime discovery with the SDK
+   validator plus compatibility checks.
+3. Add manager data fields for `validation`, `compatibility`, and
+   `capabilities`.
+4. Gate API construction by capability decisions in both renderer and main.
+5. Add tests proving granted and denied states for `git.metadata`,
+   `filesystem`, `ipc`, `settings`, `codex.windows`, and `codex.views`.
+
+Keep mutating project operations, automatic tweak updates, public app-server
+SDK exposure, and broad Codex window/view guarantees out of this slice.

--- a/research/agents/security-boundaries.md
+++ b/research/agents/security-boundaries.md
@@ -1,0 +1,146 @@
+# Security And Capability Boundaries
+
+Owner scope: recovered note from the read-only security/trust-boundary lane.
+This is product/platform guidance for Codex++ capability design. It does not
+change code.
+
+## 1. Best Immediate Wins
+
+1. Make read-only metadata ambient.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+   - Safe default: app version/platform, current route, read-only config
+     inspection, read-only git status/diff metadata inside selected workspace,
+     app-server health, update availability state, and bounded logs.
+
+2. Keep `api.git` as the model for privacy-preserving APIs.
+   - Impact: high.
+   - Effort: already started.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+   - Reason: it runs fixed git argv arrays in main, uses timeouts and byte caps,
+     returns structured metadata, and avoids raw file contents, raw hunks, and
+     credentials.
+
+3. Add explicit capability groups before exposing raw app-server access.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: app-server protocol.
+   - Suggested groups: read-only, workspace-read, workspace-write, config-write,
+     tool-exec, auth, plugin-install, MCP, update/repair.
+
+4. Add audit rows for authority increases.
+   - Impact: medium-high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: Codex++ runtime seam.
+   - Examples: enabling `danger-full-access`, network expansion, Unix socket
+     permissions, MCP config changes, plugin install, auth login/logout,
+     worktree mutation, repair/update actions.
+
+## 2. Medium Bets
+
+1. Permission enforcement matrix.
+   - Product: show declared, enforced, and advisory permissions for each tweak.
+   - Reason: today `git.metadata` is clearly gated, while some manifest
+     permissions are author declarations rather than hard runtime blocks.
+
+2. App-server typed wrapper layer.
+   - Product: expose narrow wrappers like `api.goal`, `api.thread.readonly`,
+     and `api.config.read` before any raw `api.appServer.request`.
+   - Reason: typed wrappers make permissions reviewable and keep unsafe methods
+     out of ordinary tweaks.
+
+3. Native-visible confirmation for privileged writes.
+   - Product: a modal or repair center that shows old/new values and exact
+     command/file effects before config, repair, update, or worktree mutation.
+   - Reason: renderer-originated privileged actions should not be silent.
+
+## 3. High-Risk Findings
+
+1. Raw local WebSocket app-server is spoofable if exposed without auth.
+   - Risk: any local/browser client that can reach a fixed unauthenticated port
+     can attempt privileged JSON-RPC methods.
+   - Guardrail: prefer Desktop IPC or stdio. If WebSocket is required, use a
+     random loopback port, high-entropy bearer token, Origin verification, and
+     explicit non-loopback opt-in.
+
+2. A compromised renderer can drive powerful native methods if the bridge is
+   too broad.
+   - Risk methods include config writes, external config import, command exec,
+     account login/logout, plugin install, MCP OAuth, file writes, sandbox
+     setup, and update/repair.
+   - Guardrail: do not expose raw app-server methods to ordinary tweaks.
+
+3. Renderer-controlled update repair is too privileged.
+   - Guardrail: update/repair should stay native, signed, rollback-aware,
+     user-visible, and diagnosable through status/doctor/repair surfaces.
+
+## 4. Lower-Risk Findings
+
+1. Read-only git metadata/diff summaries are reasonable when scoped to the
+   selected workspace and implemented in main.
+2. App-server goal read/write can be exposed safely as a typed feature because
+   it is thread-scoped and already has dedicated methods.
+3. Settings and observability pages are safer integration surfaces than bundle
+   patching or React/fiber mutation.
+
+## 5. Capability Policy
+
+Safe by default:
+
+- Version/platform/status.
+- Current UI route.
+- Read-only config inspection.
+- Read-only git status, branch, diff summary, and worktree metadata.
+- App-server feature detection and health.
+- Bounded local logs with redaction.
+
+Requires visible permission:
+
+- File writes.
+- Command execution.
+- Config writes.
+- Sandbox/network permission changes.
+- Plugin/tweak install.
+- MCP OAuth/config changes.
+- Account login/logout.
+- Worktree create/delete/cleanup.
+- Update/repair.
+
+Avoid:
+
+- Fixed unauthenticated app-server ports.
+- Wildcard localhost app-server access.
+- Exposing raw `ipcRenderer` events or arbitrary IPC channels.
+- Renderer-supplied update/repair commands.
+- Silent `danger-full-access` toggles.
+- DOM-driven privileged actions without schema validation and capability checks.
+
+## 6. Suggested Next Slice
+
+1. Document a permission matrix in SDK docs:
+   - permission string,
+   - current enforcement,
+   - exposed APIs,
+   - expected user-visible copy,
+   - examples.
+
+2. Add a `Trust Card` data model for tweaks:
+   - source,
+   - manifest permissions,
+   - actual gated APIs,
+   - MCP servers,
+   - update state,
+   - storage paths,
+   - loaded scopes.
+
+3. Keep raw app-server access private until wrappers exist for the common cases:
+   - `api.goal`,
+   - `api.thread.readonly`,
+   - `api.config.read`,
+   - `api.git`.
+

--- a/research/agents/tweak-ecosystem.md
+++ b/research/agents/tweak-ecosystem.md
@@ -1,0 +1,177 @@
+# Tweak Ecosystem Research Notes
+
+Scope: product and platform ideas for Codex++ tweaks/plugins. Evidence is anchored to the current repo state, especially `packages/sdk`, `packages/runtime`, `packages/installer`, and authoring docs. This file is notes-only; it does not propose code changes in this slice.
+
+## 1. Best Immediate Wins
+
+1. Ship a local "tweak catalog" before a remote marketplace.
+   - Current install/discovery is already local-folder based: a tweak is a folder with `manifest.json` plus an entry file under the user tweaks dir, and the manager renders what loads from that location. Evidence: `docs/WRITING-TWEAKS.md:3-9`, `packages/runtime/src/tweak-discovery.ts:1-9`, `packages/runtime/src/tweak-discovery.ts:22-41`.
+   - Product move: add a catalog page that indexes installed tweaks, default tweaks, disabled tweaks, update status, permissions, source repo, homepage, author, tags, scope, MCP server, and storage footprint. This can be backed by the already-returned `codexpp:list-tweaks` shape: manifest, entry, dir, entryExists, enabled, and update metadata. Evidence: `packages/runtime/src/main.ts:435-445`, `packages/runtime/src/preload/tweak-host.ts:25-40`.
+   - Why first: it gives the marketplace UX shape without introducing remote install trust decisions yet.
+
+2. Treat permissions as first-class UX now, even before hard enforcement is complete.
+   - The manifest already supports `permissions`, and the SDK enumerates known strings: `ipc`, `filesystem`, `network`, `settings`, `codex.windows`, `codex.views`, and `git.metadata`. Evidence: `packages/sdk/src/index.ts:44-50`, `packages/sdk/src/index.ts:64-83`.
+   - The validator only checks that listed permissions are known; it does not currently block API access for most capabilities. Git is the clearest gated API: renderer `api.git` is only exposed when `manifest.permissions` includes `git.metadata`. Evidence: `packages/sdk/src/index.ts:169-185`, `packages/runtime/src/preload/tweak-host.ts:160-218`.
+   - Product move: show "declared" vs "currently enforced" permission badges. Do not imply sandbox guarantees that do not exist. Use labels like "Git metadata: required and gated", "Filesystem: scoped to tweak data dir", "IPC: namespaced channel", and "Network: declared by author, not runtime blocked yet".
+
+3. Expand trust UX around advisory updates instead of installing updates automatically.
+   - Current update policy is deliberately manual: manifests require `githubRepo`; update checks hit GitHub Releases at most daily; the runtime only reports availability and never auto-installs tweak updates. Evidence: `packages/sdk/src/index.ts:16-21`, `docs/ARCHITECTURE.md:37-42`, `docs/WRITING-TWEAKS.md:63-67`, `packages/runtime/src/main.ts:757-788`.
+   - Product move: an "Update Available" details drawer should show current version, latest tag, checkedAt, release URL, repo owner/name, release-notes excerpt, and a manual "Open release" action. The open-external handler already limits metadata links to `https://github.com`. Evidence: `packages/runtime/src/main.ts:578-583`.
+   - Trust move: add warnings for repo mismatch, missing release, non-semver version, unverified author metadata, or update-check error. The SDK already produces semver warnings and GitHub repo validation errors. Evidence: `packages/sdk/src/index.ts:120-135`.
+
+4. Make the bundled/default tweak lane visible and reversible.
+   - The installer seeds default tweaks from external GitHub release tarballs, skips if the local folder already exists, and strips `.git` and `node_modules` during copy. Evidence: `docs/ARCHITECTURE.md:43-45`, `packages/installer/src/default-tweaks.ts:14-23`, `packages/installer/src/default-tweaks.ts:34-55`, `packages/installer/src/default-tweaks.ts:118-123`.
+   - Product move: the manager should label default tweaks as "Bundled by Codex++ installer" or "Default catalog", not as app-internal code. Existing local tweak folders are not overwritten, so users need "reset/reinstall default tweak" as a future explicit action rather than silent replacement.
+   - Trust move: for default tweaks, show source repo and release provenance in the same format as third-party tweaks. Defaults should not get a hidden trust path.
+
+5. Turn `dev` into a polished developer mode, not just a CLI command.
+   - The CLI can validate a manifest, symlink a tweak into the tweaks dir, write a reload marker, and optionally watch source changes while ignoring `node_modules`. Evidence: `packages/installer/src/commands/dev-tweak.ts:24-45`, `packages/installer/src/commands/dev-tweak.ts:79-100`, `packages/installer/src/commands/dev-tweak.ts:124-147`.
+   - Runtime also has a manual force-reload IPC path and a chokidar watcher that debounces changes and broadcasts reloads to renderers. Evidence: `packages/runtime/src/main.ts:591-610`, `packages/runtime/src/main.ts:613-628`, `packages/runtime/src/main.ts:845-857`.
+   - Product move: add a "Developer Mode" panel showing linked tweak source, symlink target, last validation result, last reload reason, last error, and a force reload button. This can be built from existing CLI/runtime primitives before new APIs.
+
+6. Document the API maturity levels beside the SDK types.
+   - SDK API surface currently spans settings pages/sections, React fiber utilities, IPC, filesystem, storage, git metadata, logging, and main-process Codex window/view APIs. Evidence: `packages/sdk/src/index.ts:262-284`, `packages/sdk/src/index.ts:300-341`, `packages/sdk/src/index.ts:347-385`, `packages/sdk/src/index.ts:387-430`.
+   - Some APIs are more stable than others. Settings and storage are product primitives; React fiber access is intentionally advanced and brittle; Codex window services depend on patched host internals. Evidence: `docs/WRITING-TWEAKS.md:93-101`, `docs/ARCHITECTURE.md:117-121`.
+   - Product move: tag APIs as Stable, Advanced, Experimental, or Host-internal. This will reduce marketplace review ambiguity and help tweak authors avoid brittle hooks when a supported extension point exists.
+
+7. Make storage behavior honest and inspectable.
+   - Runtime main storage is disk-backed JSON under `<userRoot>/storage/<id>.json`, debounced and atomic; renderer storage currently uses `localStorage`; filesystem helpers are scoped to `<userRoot>/tweak-data/<id>/`. Evidence: `packages/runtime/src/storage.ts:1-7`, `packages/runtime/src/storage.ts:27-87`, `packages/runtime/src/preload/tweak-host.ts:221-245`, `packages/runtime/src/main.ts:535-552`, `docs/WRITING-TWEAKS.md:145-147`.
+   - The docs still say main storage is currently in-memory and will move to disk, which appears stale against `createDiskStorage`. Evidence: `docs/WRITING-TWEAKS.md:103-106`, `packages/runtime/src/main.ts:657-670`.
+   - Product move: expose "data stored by this tweak" with paths and clear-data actions. Documentation move for a later slice: update the storage docs to match the implementation.
+
+8. Expose MCP integration as a trust-sensitive capability, not just a manifest field.
+   - Tweaks can declare an optional MCP server in the manifest; Codex++ syncs enabled tweak MCP servers into `~/.codex/config.toml` inside a managed block. Evidence: `packages/sdk/src/index.ts:44-48`, `packages/runtime/src/mcp-sync.ts:5-7`, `packages/runtime/src/main.ts:680-698`.
+   - The MCP sync respects manually configured server names, reserves unique names, resolves relative commands/args against the tweak dir, and writes env vars into the config. Evidence: `packages/runtime/src/mcp-sync.ts:49-69`, `packages/runtime/src/mcp-sync.ts:141-155`, `packages/runtime/src/mcp-sync.ts:158-167`.
+   - Product move: show MCP as "adds chat tools" with command, args, env key names, and config destination. Hide env values by default. Require explicit enablement for third-party MCP servers even if the tweak itself is enabled.
+
+## 2. Medium Bets
+
+1. Marketplace model: GitHub-release registry with local install receipts.
+   - Fit with current architecture: manifests already require `githubRepo`, release checks already use GitHub Releases, default tweaks already install from GitHub release tarballs, and Codex++ self-update already downloads GitHub release source. Evidence: `packages/runtime/src/main.ts:790-828`, `packages/installer/src/default-tweaks.ts:77-95`, `packages/installer/src/commands/self-update.ts:121-150`.
+   - Proposed registry primitive: a signed or reviewed JSON index containing id, name, repo, latest version, tags, permission summary, MCP summary, default/bundled flag, screenshots, and review status. Actual install still downloads a release artifact and validates `manifest.json`.
+   - Keep phase 1 GitHub-native: do not invent accounts, payments, or package hosting until the trust UX and install receipt model are correct.
+
+2. Install receipts and provenance checks.
+   - Current default-tweak install copies release contents into the tweaks dir but does not appear to write a provenance receipt per tweak. Evidence: `packages/installer/src/default-tweaks.ts:58-75`, `packages/installer/src/default-tweaks.ts:118-123`.
+   - Proposed receipt: `<tweak-data or metadata>/<id>/install.json` with source kind, repo, release tag, asset URL, digest, installedAt, installer version, manifest snapshot, and whether installed by default, marketplace, dev symlink, or manual copy.
+   - UX impact: trust panel can distinguish "manually dropped folder" from "installed from reviewed catalog release".
+
+3. Permission enforcement in the runtime API factory.
+   - Renderer git is currently permission gated; renderer fs/ipc/settings/storage are provided regardless of declared permissions. Main tweaks receive git, codex, fs, ipc, storage, and log unconditionally once loaded. Evidence: `packages/runtime/src/preload/tweak-host.ts:160-218`, `packages/runtime/src/main.ts:653-667`.
+   - Proposed enforcement order: warn-only in catalog, deny newly dangerous APIs for unlisted permissions in dev builds, then require permissions for marketplace-installed tweaks. Keep manual/local tweaks flexible behind developer mode.
+   - Avoid overclaiming: JavaScript running in preload/main still has broad possibilities. The permission system is an API exposure and review contract, not a perfect sandbox.
+
+4. Tweak signing or digest pinning before one-click install.
+   - Today the safest path is manual update review because the runtime never auto-installs tweak updates. Evidence: `docs/ARCHITECTURE.md:37-42`.
+   - For marketplace install, require release artifact digest pinning at minimum. For higher trust, accept Sigstore/GitHub artifact attestations or a Codex++ registry signature.
+   - Product decision: if unsigned, install can still be allowed in developer mode but should show a clear "unverified source" state.
+
+5. Marketplace review pipeline focused on declared behavior, not full code ownership.
+   - Manifest schema gives enough hooks for automated review: id/name/version/repo, scope, permissions, MCP, tags, minRuntime, entry. Evidence: `packages/sdk/src/index.ts:9-51`, `packages/sdk/src/index.ts:96-187`, `packages/installer/src/commands/validate-tweak.ts:8-40`.
+   - Review bot can run `validate-tweak`, inspect package size, detect bundled dependencies, extract MCP command/env names, lint for obvious network/process/fs use, and render a static trust card.
+   - The marketplace should not imply full security audit unless there is a real audit process.
+
+6. Runtime compatibility and deprecation channels.
+   - Manifests include `minRuntime`, but discovery currently only validates id/name/version/githubRepo/scope and does not appear to reject incompatible runtime ranges. Evidence: `packages/sdk/src/index.ts:38-43`, `packages/runtime/src/tweak-discovery.ts:44-49`.
+   - Product move: manager should warn on unknown/newer `minRuntime` now; later runtime should refuse incompatible marketplace installs.
+   - Platform move: maintain SDK changelog plus compatibility matrix for Stable vs Experimental APIs.
+
+7. Storage migration and backup UX.
+   - Main storage now uses disk JSON with corrupt-file preservation; renderer storage uses localStorage and is less discoverable/portable. Evidence: `packages/runtime/src/storage.ts:32-44`, `packages/runtime/src/preload/tweak-host.ts:221-245`.
+   - Medium bet: move renderer storage through main IPC to the same disk-backed store, then make "export tweak data", "clear tweak data", and "include in backup" consistent.
+
+8. Safer filesystem and path handling.
+   - Renderer filesystem IPC rejects ids outside a pattern and rejects paths containing `..`, then joins under `<userRoot>/tweak-data/<id>`. Evidence: `packages/runtime/src/main.ts:535-552`.
+   - Medium bet: replace substring traversal checks with `resolve` plus prefix checks, matching the stricter asset-source checks. Evidence for stricter pattern: `packages/runtime/src/main.ts:474-483`, `packages/runtime/src/main.ts:490-523`.
+
+## 3. Wild Ideas Or Moonshots
+
+1. "Tweak Studio" inside Codex++.
+   - Build a local authoring surface that scaffolds via `create-tweak`, runs validation, links via `dev`, watches reloads, displays logs, and includes starter components for settings pages. CLI primitives already exist. Evidence: `packages/installer/src/cli.ts:129-150`, `packages/installer/src/commands/create-tweak.ts:18-79`, `packages/installer/src/commands/dev-tweak.ts:24-45`.
+
+2. Capability-scoped MCP marketplace.
+   - Tweak marketplace entries could expose both UI extensions and chat/tool extensions. MCP servers declared by tweaks already sync into Codex config. Evidence: `packages/runtime/src/mcp-sync.ts:26-43`, `packages/runtime/src/mcp-sync.ts:141-155`.
+   - Long-term UX: users install "workspace tools" with explicit chat-tool permissions, then enable them per project/repo.
+
+3. Trust scorecards generated from release artifacts.
+   - For every candidate tweak release, generate a scorecard: manifest validity, permissions, API usage, MCP command, env keys, package size, dependency tree, source repo age, signed tags, release digest, and screenshots.
+   - Keep the scorecard evidence-based and avoid opaque star ratings.
+
+4. Tweak collections.
+   - Let users install curated sets like "Git workflow", "UI polish", "Agent ops", or "Research dashboard". Default tweaks are already an implicit collection of two repos. Evidence: `packages/installer/src/default-tweaks.ts:14-23`.
+   - Trust caveat: collection install must still show individual permission/MCP/storage/repo cards.
+
+5. Per-workspace enablement.
+   - Today enablement appears global in `config.json`, keyed by tweak id, with safe mode globally disabling all tweaks. Evidence: `packages/runtime/src/main.ts:126-134`, `packages/installer/src/commands/safe-mode.ts:36-48`.
+   - A future project profile could enable a tweak only for selected repos, especially for git/MCP/network-heavy tools.
+
+## 4. Constraints And Exact Evidence
+
+1. Distribution is currently local and GitHub-release-oriented.
+   - Local tweak folders: `docs/WRITING-TWEAKS.md:3-9`.
+   - Default tweaks from GitHub releases: `packages/installer/src/default-tweaks.ts:34-75`.
+   - Self-update from GitHub latest release/source tarball: `packages/installer/src/commands/self-update.ts:68-83`.
+
+2. No automatic third-party tweak updates today.
+   - SDK manifest comment: `packages/sdk/src/index.ts:16-21`.
+   - Architecture doc: `docs/ARCHITECTURE.md:37-42`.
+   - Runtime update check cache/write: `packages/runtime/src/main.ts:757-788`.
+
+3. Runtime loading model has real trust implications.
+   - Renderer tweak source is read by main and evaluated with `new Function` in preload because the renderer is sandboxed and cannot require arbitrary files. Evidence: `packages/runtime/src/preload/tweak-host.ts:1-13`, `packages/runtime/src/preload/tweak-host.ts:104-124`.
+   - Main-scope tweaks are loaded with `require(t.entry)` and receive main APIs. Evidence: `packages/runtime/src/main.ts:647-667`.
+   - Therefore marketplace UX must be explicit that a tweak is executable code, not a declarative theme.
+
+4. Settings/UI integration is heuristic and should be presented as best-effort.
+   - The injector identifies Codex settings by DOM text/content and injects sidebar groups/panels. Evidence: `packages/runtime/src/preload/settings-injector.ts:1-22`, `packages/runtime/src/preload/settings-injector.ts:298-320`.
+   - Architecture docs acknowledge settings DOM changes can break injection. Evidence: `docs/ARCHITECTURE.md:117-121`.
+
+5. Safe mode and per-tweak enablement are already available trust controls.
+   - Global safe mode disables all tweaks until turned off and preserves per-tweak flags. Evidence: `packages/installer/src/commands/safe-mode.ts:36-48`.
+   - Runtime checks safe mode before considering per-tweak enabled flags. Evidence: `packages/runtime/src/main.ts:126-134`.
+
+6. MCP sync modifies user Codex config, so it needs unusually clear consent.
+   - Config path is `~/.codex/config.toml` from runtime main. Evidence: `packages/runtime/src/main.ts:36-37`.
+   - Managed block markers are explicit and merge preserves manual config outside the block. Evidence: `packages/runtime/src/mcp-sync.ts:5-7`, `packages/runtime/src/mcp-sync.ts:82-95`.
+   - Existing manual MCP names are detected and skipped. Evidence: `packages/runtime/src/mcp-sync.ts:49-69`.
+
+7. Git metadata is the best current model for privacy-preserving APIs.
+   - Docs say the git API returns structured metadata and intentionally avoids raw diff hunks, file contents, credentials, and ignored trees by default. Evidence: `docs/WRITING-TWEAKS.md:128-143`.
+   - Implementation uses bounded git subprocesses with default timeout and output caps. Evidence: `packages/runtime/src/git-metadata.ts:1-5`, `packages/runtime/src/git-metadata.ts:175-200`, `packages/runtime/src/git-metadata.ts:216-240`.
+
+8. Installer patching is invasive but designed to be reversible/repairable.
+   - Architecture: app asar entry is patched, loader injected, fuse changed, plist integrity updated, runtime lives in user dir. Evidence: `docs/ARCHITECTURE.md:3-35`.
+   - Installer backs up originals before patching, stages runtime, injects loader, updates integrity, flips fuse, and signs. Evidence: `packages/installer/src/commands/install.ts:61-99`.
+   - Product trust UX should separate "Codex++ system patch trust" from "individual tweak trust".
+
+## 5. Suggested Next Slice
+
+1. Write a product spec for a local Tweak Center:
+   - Installed catalog.
+   - Default tweak provenance.
+   - Permission and MCP badges.
+   - Update details drawer.
+   - Dev mode panel.
+   - Safe mode status.
+   - Storage/data controls.
+
+2. Add a machine-readable trust card schema before implementing UI:
+   - Inputs: manifest, discovery result, update check, install receipt if present, validation warnings/errors, MCP sync summary, storage paths, enabled state, default/dev/manual source.
+   - Output: stable JSON that UI, CLI `status`, and future marketplace can render consistently.
+
+3. Tighten docs to match runtime truth:
+   - Update storage docs because main storage appears disk-backed now, not in-memory.
+   - Mark React fiber and Codex window APIs as advanced/experimental.
+   - Add explicit "tweaks are executable code" trust language.
+
+4. Build marketplace in three phases:
+   - Phase 1: local catalog plus GitHub release update UX; no remote install.
+   - Phase 2: reviewed registry with manual download/open-release flow and install receipts.
+   - Phase 3: one-click install gated by digest/signature/provenance checks and explicit permission/MCP consent.
+
+5. Highest-risk implementation questions to answer before one-click distribution:
+   - Should marketplace-installed tweaks be required to declare all used permissions?
+   - Should MCP servers require separate consent from tweak enablement?
+   - Where should install receipts live: `state.json`, per-tweak metadata, or a new registry DB?
+   - Can renderer storage be migrated to disk-backed IPC without breaking existing localStorage-backed tweaks?
+   - What is the minimum attestation standard for a "reviewed" tweak: digest pin, signed release, GitHub provenance, or Codex++ registry signature?

--- a/research/agents/update-resilience.md
+++ b/research/agents/update-resilience.md
@@ -1,0 +1,275 @@
+# Update Resilience Notes
+
+Scope: product and engineering improvements for Codex app updates breaking Codex++ niceties.
+
+Current live state on 2026-05-01:
+
+- `codex-plusplus status` reports Codex++ `0.1.4`, app root `/Applications/Codex.app`, Codex `26.429.20946`, channel `stable`, bundle id `com.openai.codex`, watcher `launchd`, safe mode disabled.
+- Integrity is currently healthy: current asar `4fcb53926b39ebc9...` matches the recorded patched hash, plist hash is OK, and the asar integrity fuse is off.
+- `launchctl print gui/$(id -u)/com.codexplusplus.watcher` shows the watcher loaded from `~/Library/LaunchAgents/com.codexplusplus.watcher.plist`, not running, last exit code `0`, watching `/Applications/Codex.app/Contents/Resources/app.asar`, and running hourly.
+- The installed Codex app plist exposes `CFBundleIdentifier=com.openai.codex`, `CFBundleShortVersionString=26.429.20946`, and `SUPublicEDKey=rhcBvttuqDFriyNqwTQJR3L4UT1WjIK4QxtwtwusVic=`.
+
+## 1. Best Immediate Wins
+
+### 1.1 Add a first-class update resilience status surface
+
+- `Impact`: high
+- `Effort`: small
+- `Confidence`: high
+- `Dependency`: Codex++ runtime seam, installer CLI
+
+Make the Settings page expose the same high-signal fields as `codex-plusplus status`: Codex++ version, Codex version, channel, bundle id, watcher kind, asar drift state, plist hash state, fuse state, update-mode state, and last watcher run. The CLI already computes most of this in `status`, but today the user only sees it if they know to run a terminal command.
+
+Evidence:
+
+- `packages/installer/src/commands/status.ts:12-38` prints user dir, tweaks dir, log dir, safe mode, installed version, app root, Codex version/channel/bundle id, fuse, resign, and watcher.
+- `packages/installer/src/commands/status.ts:48-85` compares the current asar header against `state.patchedAsarHash`, prints update mode if present, checks plist integrity, and reads the asar fuse.
+- `packages/installer/src/state.ts:7-32` already persists the status contract: Codex++ version, install time, app root, original/patched asar hashes, Codex version/channel/bundle id, fuse, resign, original entry, watcher, and runtime refresh time.
+
+Suggested product shape:
+
+- A compact "Update Health" row in Settings.
+- States: `Healthy`, `Codex updating`, `Codex++ paused`, `Repair needed`, `Repair failed`, `Watcher missing`, `Unsupported Codex version`.
+- One primary action per state: `Repair now`, `Open logs`, `Restore signed app for updater`, or `Restart Codex`.
+
+### 1.2 Persist watcher health, not just watcher kind
+
+- `Impact`: high
+- `Effort`: small to medium
+- `Confidence`: high
+- `Dependency`: installer CLI
+
+The watcher can be installed and still fail later because the pinned Node path moves, the launchd job loses permissions, the app path changes, or the CLI path is stale. Persist a small heartbeat record each time the watcher starts and exits: timestamp, command, CLI path, Node path, result, app version observed, asar hash observed, and action taken.
+
+Evidence:
+
+- `packages/installer/src/watcher.ts:60-64` writes a launchd command that hardcodes `process.execPath` and `currentCliPath()`.
+- The live launchd job currently uses `/opt/homebrew/Cellar/node/25.2.1/bin/node` and `/Users/af/codex-plusplus/packages/installer/dist/cli.js`; this works now, but the Node Cellar path is versioned and can drift after Homebrew upgrades.
+- `packages/installer/src/watcher.ts:87-90` logs stdout/stderr to `~/Library/Logs/codex-plusplus-watcher.log`, but `status` does not summarize last run or last error.
+- `packages/installer/src/commands/repair.ts:236-247` refreshes the watcher and warns only when not quiet; watcher-driven repairs run quiet, so the user can miss recurring failures.
+
+Suggested engineering shape:
+
+- Add `<user-data-dir>/watcher-health.json`.
+- Write `startedAt`, `finishedAt`, `exitCode`, `phase`, `nodePath`, `cliPath`, `codexVersion`, `asarHash`, `action`, and a bounded error summary.
+- Teach `status` and the runtime Settings page to render the latest watcher heartbeat.
+
+### 1.3 Make `repair --quiet` quiet for normal success, not invisible on failure
+
+- `Impact`: high
+- `Effort`: small
+- `Confidence`: high
+- `Dependency`: installer CLI, notification UX
+
+Watcher repair should be silent for healthy no-ops and successful repairs, but visible and actionable when it cannot restore Codex++. Right now generic CLI failures show a terminal report URL and `repair` failures try an AppleScript alert, but quiet watcher mode can still disappear into launchd logs if AppleScript fails.
+
+Evidence:
+
+- `packages/installer/src/cli.ts:28-44` wraps command failures, prints a GitHub issue URL, and exits nonzero.
+- `packages/installer/src/cli.ts:55-59` only calls `showPatchFailedAlert` for the `repair` command.
+- `packages/installer/src/alerts.ts:11-26` offers a "Report on GitHub" action for patch failures.
+- `packages/installer/src/alerts.ts:150-160` implements notifications with `osascript display notification`, which is best-effort and swallowed on failure.
+
+Suggested engineering shape:
+
+- Keep AppleScript dialogs for blocking choices, but use macOS `UserNotifications.framework` for durable local notifications from a tiny helper app or signed companion. Apple documents local notifications as the supported way for an app to present alerts even when not foregrounded.
+- Add a fallback `codex-plusplus status --json` plus `codex-plusplus repair --explain-last-failure` so the UI and terminal show the same diagnosis.
+
+### 1.4 Harden auto-repatch around the "Codex is still running" path
+
+- `Impact`: high
+- `Effort`: medium
+- `Confidence`: high
+- `Dependency`: installer CLI, native Codex seam
+
+Current repair correctly avoids patching under a running macOS app unless the user accepts restart. The weak spot is the period where Codex has updated and launched without Codex++; the user may not know the niceties are unavailable or why.
+
+Evidence:
+
+- `packages/installer/src/commands/repair.ts:49-80` announces update detection, waits for macOS update files to settle, checks update mode, then compares current asar hash to the patched hash.
+- `packages/installer/src/commands/repair.ts:119-128` prompts to quit/repatch if Codex is running; if the user declines, repair is postponed and Codex keeps running without the updated Codex++ patch.
+- `packages/installer/src/alerts.ts:89-105` asks for "Restart and Re-Patch" and returns `false` when the user chooses later.
+
+Suggested product shape:
+
+- Record `repairPostponedAt` and `reason=codex-running`.
+- Surface "Codex is running without Codex++ after update" in the next injected runtime if possible, or in the companion status if not injected.
+- Add `codex-plusplus repair --when-codex-quits` to park a one-shot launchd job that waits for Codex exit, patches, then reopens.
+
+### 1.5 Add compatibility gating before writing the patch
+
+- `Impact`: high
+- `Effort`: medium
+- `Confidence`: medium
+- `Dependency`: native Codex seam, installer CLI
+
+Codex++ should distinguish "known compatible", "unknown but likely compatible", and "known incompatible" Codex versions before mutating the app. The installer already records versions and can read bundle metadata; the missing piece is a compatibility matrix tied to hook probes.
+
+Evidence:
+
+- `packages/installer/src/platform.ts:104-110` infers stable versus beta channel from bundle id/name.
+- `packages/installer/src/commands/install.ts:53-55` reads and prints Codex version/channel before patching.
+- `packages/installer/src/commands/install.ts:224-237` searches for the Codex window services hook and throws `Codex window services hook point not found` if the minified app shape has changed.
+- `docs/ARCHITECTURE.md:117-121` already names layout changes, Settings DOM changes, and targeted anti-tamper as unprotected update classes.
+
+Suggested engineering shape:
+
+- Add `compatibility.json` keyed by Codex channel/version with required probes: package main exists, preload strategy still additive, window services hook found, Settings mount heuristic found, app-server bridge shape.
+- Let `repair` run probes before mutation. If unknown, create a full backup and proceed with a visible "experimental compatibility" state; if known bad, stop before writing and show the exact failing probe.
+
+## 2. Medium Bets
+
+### 2.1 Split runtime staging into stable, candidate, and active slots
+
+- `Impact`: medium to high
+- `Effort`: medium
+- `Confidence`: high
+- `Dependency`: Codex++ runtime seam
+
+`repair` can refresh runtime assets when the app patch is intact and Codex++ version advances. Today `stageAssets(paths.runtime)` writes directly into the active runtime directory. Use staged slots so a bad Codex++ runtime update does not break the currently working injected runtime.
+
+Evidence:
+
+- `packages/installer/src/commands/repair.ts:78-105` refreshes runtime assets when the asar patch is intact and `CODEX_PLUSPLUS_VERSION` is newer than `state.version`.
+- `packages/installer/src/commands/install.ts:78-80` stages runtime before app patching.
+- `packages/installer/src/commands/install.ts:250-267` copies assets directly into `runtimeDir`.
+- `packages/installer/src/paths.ts:8-15` defines a single `runtime/` directory and a single `backup/` directory.
+
+Suggested engineering shape:
+
+- Write `runtime/releases/<codexpp-version>/`.
+- Keep `runtime/active` as a symlink or manifest pointer.
+- Let the loader read an atomic manifest first; on failure, fall back to previous active runtime.
+- Add `runtimeUpdatedAt`, `runtimeActiveVersion`, `runtimePreviousVersion`, and `runtimeCandidateVersion` to state.
+
+### 2.2 Treat `update-codex` as a guided repair/update wizard
+
+- `Impact`: medium
+- `Effort`: medium
+- `Confidence`: high
+- `Dependency`: installer CLI, repair UX
+
+`update-codex` already knows how to restore a signed app from a pristine backup or Sparkle cache, pause Codex++ patching with update mode, install the watcher, and reopen Codex. This is close to a product-quality "let official updater run" flow, but it is CLI-only and state is only loosely visible.
+
+Evidence:
+
+- `packages/installer/src/commands/update-codex.ts:38-45` finds a signed backup or Sparkle-cached app and gives a specific recovery error if none exists.
+- `packages/installer/src/commands/update-codex.ts:53-59` writes update mode and installs the watcher.
+- `packages/installer/src/commands/update-codex.ts:65-78` parks the patched app, restores a signed app, clears quarantine, and verifies signature.
+- `packages/installer/src/update-mode.ts:3-45` models a six-hour update-mode window and describes stale paused state.
+
+Suggested product shape:
+
+- Settings button: "Update Codex safely".
+- Steps: verify signed backup, restore signed app, launch Codex updater, show paused state, detect new version, reapply Codex++, restart Codex.
+- Persist each phase so interrupted flows resume instead of forcing the user to remember terminal commands.
+
+### 2.3 Add a backup manifest and restore policy
+
+- `Impact`: medium
+- `Effort`: medium
+- `Confidence`: high
+- `Dependency`: installer CLI
+
+The backup directory is crucial, but it is mostly implicit. Add a manifest that records what each backup can restore, source signature status, Codex version/channel, hash, creation time, and whether it was verified after copy.
+
+Evidence:
+
+- `packages/installer/src/commands/install.ts:61-74` backs up signed Codex.app, app.asar, app.asar.unpacked, Info.plist, and Electron Framework.
+- `packages/installer/src/commands/install.ts:169-175` only keeps a pristine app backup if signature info is valid, non-ad-hoc, and has a team identifier.
+- `packages/installer/src/commands/update-codex.ts:92-109` chooses Sparkle cache candidates before pristine backup and prefers newer signed versions.
+- `packages/installer/src/state.ts:12-15` stores original and patched asar hashes, but not a backup inventory.
+
+Suggested engineering shape:
+
+- Add `<user-data-dir>/backup/manifest.json`.
+- Store entries for `pristine-app`, `prepatch-asar`, `plist`, `framework`, and `parked-patched-app`.
+- Include `verifiedAt`, `teamIdentifier`, `adHoc`, `codexVersion`, `hash`, `path`, and `restoreCommand`.
+- Status should warn when a backup is missing or older than the recorded install.
+
+### 2.4 Add a post-update synthetic smoke test
+
+- `Impact`: medium
+- `Effort`: medium
+- `Confidence`: medium
+- `Dependency`: Codex++ runtime seam, app-server protocol
+
+After repair succeeds, automatically confirm the injected runtime is actually alive. Hash equality proves the patch is on disk; it does not prove the runtime loaded, the Settings affordance mounted, or the app-server bridge still works.
+
+Evidence:
+
+- `packages/installer/src/commands/status.ts:59-85` checks disk integrity and fuse state only.
+- `docs/ARCHITECTURE.md:119-120` notes DOM heuristic drift as a separate failure mode from asar layout drift.
+- `research/README.md:22-29` records current runtime features that depend on app-server and preload bridges, including `/goal` and git metadata.
+
+Suggested engineering shape:
+
+- Add a renderer heartbeat file or IPC ping from runtime load.
+- Store last runtime heartbeat by Codex version and Codex++ version.
+- If disk repair succeeds but runtime heartbeat never appears after launch, status should say "patched on disk, runtime not observed".
+
+## 3. Wild Ideas Or Moonshots
+
+### 3.1 Companion menu bar app for update state
+
+- `Impact`: medium
+- `Effort`: large
+- `Confidence`: medium
+- `Dependency`: external service, installer CLI
+
+A tiny signed companion app could own notifications, repair prompts, status UI, logs, and update orchestration without depending on injected Codex UI. This is the cleanest product surface for the moments when Codex++ is not injected because Codex just updated.
+
+Evidence:
+
+- All current UI prompts are AppleScript shell-outs from `packages/installer/src/alerts.ts:144-160`.
+- Once Sparkle replaces Codex.app, Codex++ cannot rely on injected renderer UI until repair succeeds, as described in `docs/ARCHITECTURE.md:101-108`.
+
+### 3.2 Compatibility canary for new Codex releases
+
+- `Impact`: high
+- `Effort`: large
+- `Confidence`: medium
+- `Dependency`: native Codex seam, external service
+
+Run a CI or local scheduled canary against new Codex appcast releases before users hit them. It would download the latest signed Codex, run patch probes, produce a compatibility verdict, and publish a small manifest consumed by `repair`.
+
+Evidence:
+
+- The live Codex app has Sparkle metadata and a public key in `Info.plist`; the root package metadata also carries `codexSparkleFeedUrl` and `codexSparklePublicKey`.
+- `packages/installer/src/commands/update-codex.ts:111-120` already knows Sparkle cache layout for installed updates.
+- Sparkle documentation treats regular app bundles and archives as normal update artifacts; package installers are documented as a special case for custom needs.
+
+### 3.3 Multi-strategy patch backend
+
+- `Impact`: moonshot
+- `Effort`: large
+- `Confidence`: low to medium
+- `Dependency`: native Codex seam
+
+Keep current asar entry patch as the default, but add a strategy registry for future Codex layouts: asar package main patch, Electron session preload append, launcher wrapper, or companion-only mode. This turns "Codex layout changed" into a strategy negotiation instead of a binary failure.
+
+Evidence:
+
+- `packages/installer/src/commands/install.ts:178-221` has a single injection strategy: rewrite `package.json#main`, copy `codex-plusplus-loader.cjs`, and patch window services.
+- `docs/ARCHITECTURE.md:79-93` explains why the current patch is efficient and why runtime lives outside the app, but also names layout changes as a class of breakage.
+
+## 4. Constraints And Exact Evidence
+
+- Do not patch while Codex is actively running unless the user accepts restart. Current repair enforces this on macOS in `packages/installer/src/commands/repair.ts:119-128`.
+- Do not erase user tweaks during repair or runtime refresh. The architecture states self-update repair refreshes runtime and state without modifying user tweak folders in `docs/ARCHITECTURE.md:109-113`.
+- Watcher reinstallation must preserve an explicit no-watcher install. `packages/installer/src/commands/repair.ts:133-139` passes `watcher: state?.watcher === "none" ? false : true`.
+- Update mode must expire. `packages/installer/src/update-mode.ts:3-45` defines a six-hour freshness window and marks stale paused state.
+- The current patch health proof is disk-level, not runtime-level. `status` checks asar hash, plist hash, and fuse state in `packages/installer/src/commands/status.ts:59-85`.
+- External primitive note: prefer `UserNotifications.framework` for durable macOS local notifications over raw `osascript display notification`; Apple documents it as the framework for local and remote user-facing notifications. Keep AppleScript dialogs only where a terminal process needs a synchronous choice.
+- External Sparkle note: treat Sparkle as the source of truth for official Codex app replacement, but do not try to become a Sparkle plugin inside Codex. Sparkle docs discourage package-style update paths unless there is a custom installation need, and Codex++ should stay outside the official updater boundary.
+
+## 5. Suggested Next Slice
+
+Implement the smallest resilience slice in this order:
+
+1. Add `watcher-health.json` and write it from watcher-launched `update` and `repair` paths.
+2. Extend `status` with watcher heartbeat, last repair action, update-mode age, and a machine-readable `--json` mode.
+3. Add a Settings "Update Health" panel that reads the same status contract.
+4. Add a one-shot "repair when Codex quits" path for postponed repairs.
+5. Add a compatibility probe file with hard stops for known-bad Codex versions and warnings for unknown versions.
+

--- a/research/evidence/README.md
+++ b/research/evidence/README.md
@@ -1,0 +1,4 @@
+# Evidence
+
+Use this folder for exact anchors, commands, screenshots, protocol snippets, and
+live-app observations that support the product research.

--- a/research/evidence/current-state.md
+++ b/research/evidence/current-state.md
@@ -1,0 +1,166 @@
+# Current State Evidence
+
+Date: 2026-05-01.
+
+## Apps
+
+Stable:
+
+- App path: `/Applications/Codex.app`.
+- Bundle id: `com.openai.codex`.
+- Codex Desktop version: `26.429.20946`.
+- Build: `2312`.
+- Embedded CLI: `codex-cli 0.128.0-alpha.1`.
+- Codex++ user dir: `/Users/af/Library/Application Support/codex-plusplus`.
+- `codex-plusplus status`: patched asar hash matches, plist hash OK, asar
+  fuse off, safe mode disabled, watcher `launchd`.
+
+Beta:
+
+- App path: `/Applications/Codex (Beta).app`.
+- Bundle id: `com.openai.codex.beta`.
+- Codex Desktop version: `26.429.21146`.
+- Build: `2317`.
+- Embedded CLI: `codex-cli 0.128.0-alpha.1`.
+- Codex++ user dir: `/Users/af/Library/Application Support/codex-plusplus-beta`.
+- `CODEX_PLUSPLUS_HOME=...beta codex-plusplus status`: patched asar hash
+  matches, plist hash OK, asar fuse off, safe mode disabled, watcher `launchd`.
+
+Both apps have `package.json#main = codex-plusplus-loader.cjs` in their
+`app.asar` and include `codex-plusplus-loader.cjs`.
+
+Homebrew CLI:
+
+- `/opt/homebrew/bin/codex --version`: `codex-cli 0.128.0`.
+
+## Local Codex Config
+
+Config path: `/Users/af/.codex/config.toml`.
+
+Important feature flags:
+
+- `[features].goals = true`.
+- `[features].multi_agent = true`.
+- `[features].plugins = true`.
+- `[features].apps = true`.
+- `[features].apps_mcp_gateway = true`.
+- `[features].shell_tool = true`.
+- `[features].unified_exec = true`.
+
+Agent controls:
+
+- `[agents].job_max_runtime_seconds = 86400`.
+- `[agents].max_depth = 64`.
+- `[agents].max_threads = 4096`.
+
+MCP servers kept enabled for this work:
+
+- `chrome-devtools`
+- `github`
+- `openaiDeveloperDocs`
+- `playwright`
+- `playwriter`
+
+MCP servers disabled for this work:
+
+- `agentation`
+- `alphaxiv`
+- `context7`
+- `figma`
+- `linear`
+- `notion`
+- `pencil`
+- `sentry`
+
+Backup before MCP trimming:
+
+- `/Users/af/.codex/config.toml.bak-20260501-072809`
+
+## Implemented In This Checkout
+
+Goal frontend:
+
+- `packages/runtime/src/preload/app-server-bridge.ts`
+- `packages/runtime/src/preload/goal-feature.ts`
+- `packages/runtime/src/preload/index.ts`
+
+Git metadata substrate:
+
+- `packages/runtime/src/git-metadata.ts`
+- `packages/runtime/test/git-metadata.test.ts`
+- `packages/runtime/src/main.ts`
+- `packages/runtime/src/preload/tweak-host.ts`
+- `packages/sdk/src/index.ts`
+- `packages/sdk/test/manifest-validation.test.ts`
+- `docs/WRITING-TWEAKS.md`
+- `docs/GIT_METADATA_SIDEBAR.md`
+
+Generated installer payloads were rebuilt under:
+
+- `packages/installer/assets/runtime/`
+
+## Verification Already Run
+
+- `npx tsc -p packages/runtime/tsconfig.json --noEmit`: passed.
+- `npm test`: passed, 87 tests.
+- `git diff --check`: passed.
+- `npm run build`: passed.
+- Stable `codex-plusplus status`: patched and integrity OK.
+- Beta `CODEX_PLUSPLUS_HOME=...beta codex-plusplus status`: patched and
+  integrity OK.
+- `/opt/homebrew/bin/codex mcp list`: confirms useful MCPs enabled and unused
+  MCPs disabled.
+
+## Live App Proof
+
+Stable was relaunched with:
+
+```sh
+CODEXPP_REMOTE_DEBUG=1 CODEXPP_REMOTE_DEBUG_PORT=9222 \
+  "/Applications/Codex.app/Contents/MacOS/Codex"
+```
+
+Proof:
+
+- `http://127.0.0.1:9222/json/version` responded with
+  `Codex/26.429.20946`.
+- Main log includes `remote debugging enabled on port 9222` and
+  `preload registered`.
+- Preload log includes `goal feature started`, `boot complete`, and
+  `renderer host loaded 2 tweak(s)`.
+- CDP DOM check on `app://-/index.html?hostId=local`:
+  - `goalStyle: true`
+  - `composer: true`
+- Screenshot: `/tmp/codex-plusplus-stable.png`.
+
+Beta was relaunched with:
+
+```sh
+CODEXPP_REMOTE_DEBUG=1 CODEXPP_REMOTE_DEBUG_PORT=9223 \
+  "/Applications/Codex (Beta).app/Contents/MacOS/Codex (Beta)"
+```
+
+Proof:
+
+- `http://127.0.0.1:9223/json/version` responded with
+  `Codex(Beta)/26.429.21146`.
+- Main log includes `remote debugging enabled on port 9223` and
+  `preload registered`.
+- Preload log includes `goal feature started`, `boot complete`, and
+  `renderer host loaded 2 tweak(s)`.
+- CDP DOM check on `app://-/index.html?hostId=local`:
+  - `goalStyle: true`
+  - `goalRoot: true`
+  - `goalSuggestionRoot: true`
+  - `composer: true`
+- Screenshot: `/tmp/codex-plusplus-beta.png`.
+
+## Corrections
+
+One QA research note mentioned that `package.json` had drifted into a patched
+Codex app package. That is stale or from a different view. Current evidence:
+
+- `git diff -- package.json` is empty.
+- `shasum -a 256 package.json <(git show HEAD:package.json)` produced matching
+  hashes.
+- `package.json` still reports `name: codex-plusplus`, `version: 0.1.4`.

--- a/research/evidence/dual-channel-patching.md
+++ b/research/evidence/dual-channel-patching.md
@@ -1,0 +1,141 @@
+# Dual-Channel Patching Evidence
+
+Date: 2026-05-01.
+
+## Goal
+
+Patch and keep both installed Codex Desktop channels usable:
+
+- Stable: `/Applications/Codex.app`.
+- Beta: `/Applications/Codex (Beta).app`.
+
+## Stable
+
+Status command:
+
+```sh
+node packages/installer/dist/cli.js status
+```
+
+Verified state:
+
+- User dir: `/Users/af/Library/Application Support/codex-plusplus`.
+- App root: `/Applications/Codex.app`.
+- Codex version: `26.429.20946`.
+- Channel: `stable`.
+- Bundle id: `com.openai.codex`.
+- Fuse flipped: `true`.
+- Resigned: `true`.
+- Watcher: `launchd`.
+- Current asar: matches patched.
+- Plist hash: OK.
+- Asar fuse: off.
+
+## Beta
+
+Beta uses a separate Codex++ home so stable and beta do not fight over one
+install state:
+
+```sh
+export CODEX_PLUSPLUS_HOME="/Users/af/Library/Application Support/codex-plusplus-beta"
+node packages/installer/dist/cli.js status
+```
+
+Verified state:
+
+- User dir: `/Users/af/Library/Application Support/codex-plusplus-beta`.
+- App root: `/Applications/Codex (Beta).app`.
+- Codex version: `26.429.21146`.
+- Channel: `beta`.
+- Bundle id: `com.openai.codex.beta`.
+- Fuse flipped: `true`.
+- Resigned: `true`.
+- Watcher: `launchd`.
+- Current asar: matches patched.
+- Plist hash: OK.
+- Asar fuse: off.
+
+Beta shares the stable tweak folder through a symlink:
+
+```sh
+/Users/af/Library/Application Support/codex-plusplus-beta/tweaks
+```
+
+points to:
+
+```sh
+/Users/af/Library/Application Support/codex-plusplus/tweaks
+```
+
+## Repair Commands
+
+Stable repair:
+
+```sh
+node packages/installer/dist/cli.js repair --force
+```
+
+Beta repair:
+
+```sh
+beta_home="/Users/af/Library/Application Support/codex-plusplus-beta"
+mkdir -p "$beta_home"
+if [ ! -e "$beta_home/tweaks" ]; then
+  ln -s "/Users/af/Library/Application Support/codex-plusplus/tweaks" "$beta_home/tweaks"
+fi
+CODEX_PLUSPLUS_HOME="$beta_home" \
+  node packages/installer/dist/cli.js repair --force --app "/Applications/Codex (Beta).app"
+```
+
+## Important CLI Constraint
+
+`repair` accepts `--app`; `status` does not. Beta status must be checked by
+setting `CODEX_PLUSPLUS_HOME` to the beta user dir, then running plain
+`status`.
+
+## Important Launch Constraint
+
+Stable executable:
+
+```sh
+/Applications/Codex.app/Contents/MacOS/Codex
+```
+
+Beta executable:
+
+```sh
+/Applications/Codex (Beta).app/Contents/MacOS/Codex (Beta)
+```
+
+The beta executable is not named `Codex`; launching
+`/Applications/Codex (Beta).app/Contents/MacOS/Codex` fails with
+`no such file or directory`.
+
+Both patched app bundles record their own Codex++ runtime root in
+`package.json#__codexpp.userRoot`, so normal launches do not need
+`CODEX_PLUSPLUS_HOME`:
+
+- Stable: `/Users/af/Library/Application Support/codex-plusplus`.
+- Beta: `/Users/af/Library/Application Support/codex-plusplus-beta`.
+
+## Update Drift Root Cause
+
+Stable Codex++ niceties vanished because Sparkle replaced the patched
+`26.422` app bundle with a clean signed `26.429` app. The clean app did not
+contain `codex-plusplus-loader.cjs`, so the Codex++ runtime did not load.
+
+The watcher tried to recover but masked a failed repair:
+
+- The watcher command includes `|| true`, so launchd can report success even
+  when `repair` failed.
+- The failure was an App Management/EPERM write-probe failure under
+  `/Applications/Codex.app/Contents/Resources`.
+
+Product implication: Codex++ needs an in-app and CLI-visible update health
+state that distinguishes:
+
+- app updated and patch missing,
+- repair blocked by permissions,
+- watcher ran and repaired,
+- watcher failed but launchd masked it,
+- patched on disk but runtime not observed.

--- a/research/synthesis/README.md
+++ b/research/synthesis/README.md
@@ -1,0 +1,4 @@
+# Synthesis
+
+Integrated roadmap and decision artifacts go here after the individual agent
+notes land.

--- a/research/synthesis/constraints-map.md
+++ b/research/synthesis/constraints-map.md
@@ -1,0 +1,70 @@
+# Codex++ Constraints Map
+
+## Stable Integration Rules
+
+1. Own the bridge, not Codex internals.
+   - Preferred: Codex++ main/preload services, typed SDK APIs, Settings pages,
+     metadata-only providers, Desktop IPC app-server bridge.
+   - Avoid: hashed bundle patching, React fiber mutation, ProseMirror state
+     mutation, native slash-menu injection.
+
+2. Use current binary evidence for app-server methods.
+   - Installed stable and beta embed `codex-cli 0.128.0-alpha.1`.
+   - Homebrew CLI is `0.128.0`.
+   - `thread/goal/*` request methods are experimental; notifications exist as
+     native thread goal events.
+
+3. Treat stable and beta as separate patch targets.
+   - Stable and beta need separate Codex++ homes.
+   - Shared tweaks can be a symlink, but install state must not be shared.
+
+4. Keep renderer APIs structured and bounded.
+   - Renderer tweaks should receive typed capability objects.
+   - Main owns subprocesses, filesystem, git, and native window calls.
+   - Raw IPC/app-server access should stay private until wrappers exist.
+
+5. Prefer read-only product slices first.
+   - Git metadata.
+   - Runtime health.
+   - Goal status.
+   - Tweak catalog/trust cards.
+   - MCP preview.
+   - Project snapshot.
+
+## Hard Constraints
+
+1. Native slash-menu injection is brittle.
+   - The menu registry is private React state in hashed chunks.
+   - `/goal` should remain a composer-anchored Codex++ overlay.
+
+2. Native git surfaces are useful research, not stable APIs.
+   - Desktop has private worker methods for stable metadata, worktrees, review
+     diffs, and watchers.
+   - Native `status-summary` is count-only and does not provide per-file badges.
+   - Codex++ should keep `git-metadata.ts` as the source for sidebar badges.
+
+3. App updates can remove the patch.
+   - Sparkle installs a clean signed app.
+   - Watcher/repair failures need to be surfaced clearly.
+   - Disk integrity does not prove runtime boot.
+
+4. App-server raw access is powerful.
+   - Config writes, command exec, MCP OAuth, plugin install, auth, file writes,
+     and update/repair need typed wrappers and visible permission states.
+
+5. Large repositories need partial states.
+   - Git provider output caps and timeouts mean UI must represent `truncated`
+     as partial, not definitive.
+
+## Product Consequences
+
+1. `/goal` should be a built-in Codex++ feature first, then an SDK wrapper.
+2. Git sidebar work should ship as read-only metadata and visual badges before
+   any mutation.
+3. Observability/update health should be first-class because patch drift is a
+   normal state, not an exceptional support case.
+4. Multi-agent UX should start with ledgers, report inboxes, handoff builders,
+   and worktree visibility before automatic spawning/management.
+5. Tweak ecosystem work should start local-first: catalog, trust card, update
+   details, dev mode, and managed MCP visibility.
+

--- a/research/synthesis/product-roadmap.md
+++ b/research/synthesis/product-roadmap.md
@@ -1,0 +1,178 @@
+# Codex++ Product Roadmap
+
+This roadmap synthesizes the agent notes under `research/agents/` into ordered
+shipping slices. It favors features that use Codex++ owned seams and avoid
+private native internals.
+
+## P0: Stabilize The Foundation
+
+1. Goal command MVP.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: medium-high.
+   - Dependency: app-server protocol.
+   - Ship: `/goal`, `/goal clear`, `/goal pause`, `/goal resume`, `/goal complete`,
+     composer suggestion, status panel, unsupported-build error state.
+   - Done when: stable and beta both show preload boot, goal feature startup,
+     suggestion overlay, and real thread goal set/get/clear on a local thread.
+
+2. Dual-channel patch support.
+   - Impact: high.
+   - Effort: small.
+   - Confidence: high.
+   - Dependency: installer CLI.
+   - Ship: documented stable/beta repair commands and status checks; later add a
+     first-class `--channel beta` or multi-app status command.
+   - Done when: stable and beta install states are separate and both apps report
+     patched integrity OK.
+
+3. Project Snapshot page.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: `api.git`.
+   - Ship: branch/SHA, ahead/behind, dirty counts, changed files, insertions,
+     deletions, worktree list, partial/truncated states.
+   - Done when: clean repo, dirty repo, detached HEAD, bare repo, non-repo, and
+     linked worktree states render without raw diff/file content.
+
+4. Recovery Center.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: runtime/installer bridge.
+   - Ship: patch status, watcher health, safe mode, open logs, copy diagnostics,
+     repair command preview.
+   - Done when: the Sparkle drift class is visible as a product state instead of
+     "Codex++ disappeared".
+
+## P1: Make Daily Use Better
+
+1. Observability page.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: runtime seam.
+   - Ship: live log tail, runtime health strip, app-server request timeline,
+     goal token/budget telemetry.
+
+2. Git-aware sidebar.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: `api.git` and sidebar DOM anchors.
+   - Ship: repo header branch/dirty/ahead-behind, changed-files panel, diff
+     footer, worktree popover.
+   - Defer: mutating git actions, row mutation inside virtualized file tree,
+     conflict-resolution cockpit.
+
+3. Tweak Center.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: SDK/runtime.
+   - Ship: installed/default/dev tweak catalog, permission badges, update
+     details, storage paths, MCP declarations, trust card.
+
+4. MCP managed-config preview.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium-high.
+   - Dependency: runtime config service.
+   - Ship: managed server list, owner tweak, env key names only, collision
+     states, before/after TOML preview.
+
+5. Handoff Summary Builder.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: high.
+   - Dependency: goal + git + report inbox.
+   - Ship: cwd, repo root, branch/SHA, dirty files, current goal, finished
+     subagent cards, blockers, next actions, compact Markdown output.
+
+## P2: Agentic Workflow Layer
+
+1. Agent Run Ledger.
+   - Impact: high.
+   - Effort: medium.
+   - Confidence: medium-high.
+   - Dependency: app-server events and local storage.
+   - Ship: parent turn, spawned agents, waits, completed reports, changed files,
+     commands run, blockers.
+
+2. Subagent Report Inbox.
+   - Impact: high.
+   - Effort: small-medium.
+   - Confidence: high.
+   - Dependency: thread parsing/app-server events.
+   - Ship: structured cards for final reports with changed files, commands,
+     validation, risks, and exact next action.
+
+3. Spawn Plan Composer.
+   - Impact: high.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: native Codex seam if automatic spawning becomes available.
+   - Ship first: prompt generator with role, ownership boundary, worktree
+     guidance, report contract, validation expectations.
+
+4. Worktree Fleet Manager.
+   - Impact: high.
+   - Effort: large.
+   - Confidence: medium.
+   - Dependency: git metadata and future write permission.
+   - Ship first: read-only worktree inventory, owner notes, linked thread/report.
+   - Defer: create/delete/cleanup until command previews and permission gates.
+
+## P3: Larger Bets
+
+1. App-server typed SDK:
+   - `api.goal`
+   - `api.thread.readonly`
+   - `api.config.read`
+   - `api.appServer.features`
+
+2. Git watcher bridge:
+   - main-process watcher keyed by repo root/commonDir,
+   - debounced `codexpp:git-repo-changed`,
+   - visible stale age and manual refresh.
+
+3. Usage and cost panel:
+   - bounded session JSONL aggregation,
+   - model split,
+   - unknown pricing states,
+   - daily/hourly token trends.
+
+4. Local tweak marketplace:
+   - local catalog first,
+   - GitHub release update details,
+   - install receipts,
+   - later signed/reviewed registry.
+
+## Moonshots
+
+1. Meta-supervisor mode:
+   - detects stale agents, missing validation, overbroad prompts, write-scope
+     collisions, and finalization risk.
+
+2. Threaded goal graph:
+   - parent/child objectives, budgets, dependencies, acceptance criteria, and
+     handoff links across threads.
+
+3. Replayable agent session trace:
+   - structured timeline of messages, tool calls, diffs, checks, screenshots,
+     and final evidence with redaction at capture time.
+
+4. Compatibility canary for new Codex releases:
+   - download new signed app,
+   - run patch probes and smoke tests,
+   - publish compatibility verdict for repair/status UI.
+
+## Immediate Next Implementation Order
+
+1. Finish live QA for `/goal` on stable and beta.
+2. Add Project Snapshot settings page using `api.git`.
+3. Add Recovery Center v1 and watcher failure visibility.
+4. Add Observability page with log tail and app-server bridge timeline.
+5. Add Tweak Center trust card and MCP preview.
+


### PR DESCRIPTION
## What this does

Adds the Codex++ research map under `research/`.

The artifacts preserve the exploration phase across focused notes for:

- app-server API behavior
- runtime architecture and bundle shape
- goal workflows and native UI direction
- git sidebar ideas
- automation/live QA
- update resilience
- onboarding/settings
- tweak ecosystem
- product easy wins, wild ideas, and roadmap synthesis

## Why this is needed

The implementation work surfaced a lot of product and architecture constraints that should not live only in chat history. Keeping these notes in-repo gives future Codex++ work a grounded map of what is easy, what is risky, and what depends on native Codex internals.

## How this was proven

Docs-only change. I verified the branch is a clean worktree after committing.

## Screenshots / Visual Proof

No visual change expected. This is documentation/research content only.

## Risk / Rollout

No runtime behavior changes. The main risk is research drift; the notes are organized as dated/current evidence and synthesis so later implementation PRs can update or supersede them explicitly.
