### PR TITLE
Use stable local signing identity on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ That's it. The installer:
 3. Patches `app.asar` to require our loader.
 4. Recomputes the asar header SHA-256 and writes it into `Info.plist` (`ElectronAsarIntegrity`).
 5. Flips `EnableEmbeddedAsarIntegrityValidation` in the Electron Framework binary as a belt-and-suspenders.
-6. Re-signs the app ad-hoc on macOS (`codesign --force --deep --sign -`).
+6. Re-signs the app on macOS with a stable per-machine "Codex++ Local Signing" identity, creating it in the user keychain if needed.
 7. Installs a launch agent / login item that detects app updates and re-runs `repair --quiet`.
 8. Installs the default tweak set from their latest GitHub releases unless `--no-default-tweaks` is passed.
 
@@ -77,7 +77,7 @@ Other commands: `status`, `doctor`, `repair`, `tweaks list`, `tweaks open` (open
 
 ### Updating Codex on macOS
 
-Codex++ modifies and ad-hoc signs `Codex.app`, so Sparkle cannot safely install an
+Codex++ modifies and re-signs `Codex.app`, so Sparkle cannot safely install an
 official Codex update while the app is patched. Use:
 
 ```sh

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -80,9 +80,9 @@ The installer seeds the default tweak set from external GitHub release tarballs 
 
 The fuse alone would let us swap in a new asar, but Codex's asar is large (~115 MB) — pointlessly recopying it every install/update is slow. Patching the entry adds ~1 KB. We do flip the fuse anyway as a safety net: if a future Codex update brings asar integrity back via a different mechanism, the fuse still neutralizes it.
 
-### Why ad-hoc re-sign instead of disabling SIP?
+### Why local re-signing instead of disabling SIP?
 
-Re-signing is local-only, reversible, and doesn't compromise system security. Ad-hoc signatures are accepted by Gatekeeper for apps the user already approved. We never touch SIP, hardened runtime, or kernel-level protections.
+Re-signing is local-only, reversible, and doesn't compromise system security. On macOS, Codex++ creates and reuses a per-machine "Codex++ Local Signing" identity so privacy grants have a stable signer across repair runs. Users can still opt into ad-hoc signing with `--no-local-signing`. We never touch SIP, hardened runtime, or kernel-level protections.
 
 ### Why a preload, not source-patching the React tree?
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -11,9 +11,13 @@ codex-plusplus doctor
 If the signature check fails, manually re-sign:
 
 ```sh
-codesign --force --deep --sign - /Applications/Codex.app
+codex-plusplus repair --force
 xattr -dr com.apple.quarantine /Applications/Codex.app
 ```
+
+On macOS, Codex++ normally creates and reuses a local "Codex++ Local Signing"
+identity so privacy grants can survive future repair runs. To force the old
+ad-hoc behavior, run `codex-plusplus install --no-local-signing`.
 
 ## App launches but nothing about codex-plusplus appears
 

--- a/packages/installer/src/cli.ts
+++ b/packages/installer/src/cli.ts
@@ -20,6 +20,8 @@ interface InstallCliOpts {
   app?: string;
   fuse?: boolean;
   resign?: boolean;
+  localSigning?: boolean;
+  "local-signing"?: boolean;
   watcher?: boolean;
   defaultTweaks?: boolean;
   "default-tweaks"?: boolean;
@@ -48,6 +50,7 @@ function wrap<T extends (...args: never[]) => unknown | Promise<unknown>>(fn: T)
 function runInstall(opts: InstallCliOpts): Promise<void> {
   return install({
     ...opts,
+    localSigning: opts.localSigning ?? opts["local-signing"],
     defaultTweaks: opts.defaultTweaks ?? opts["default-tweaks"],
   });
 }
@@ -69,7 +72,8 @@ prog
   .describe("Patch Codex.app to load the tweak runtime")
   .option("--app", "Path to Codex.app / install dir (auto-detected if omitted)")
   .option("--fuse", "Flip Electron's embedded asar integrity fuse", true)
-  .option("--resign", "Ad-hoc code sign Codex.app on macOS", true)
+  .option("--resign", "Code sign Codex.app on macOS", true)
+  .option("--local-signing", "Use a stable local signing identity on macOS", true)
   .option("--watcher", "Install the auto-repair watcher", true)
   .option("--default-tweaks", "Install the default tweak set from latest GitHub releases", true)
   .action(wrap(runInstall));

--- a/packages/installer/src/codesign.ts
+++ b/packages/installer/src/codesign.ts
@@ -31,6 +31,13 @@ export interface CodeSigningResult {
 export interface CodeSigningOptions {
   useLocalIdentity?: boolean;
   identityName?: string;
+  preparedIdentity?: PreparedSigningIdentity | null;
+}
+
+export interface PreparedSigningIdentity {
+  name: string;
+  hash: string;
+  created: boolean;
 }
 
 const MACHO_MAGICS = new Set([
@@ -46,7 +53,7 @@ export function signCodexApp(appRoot: string, opts: CodeSigningOptions = {}): Co
 
   const useLocalIdentity = opts.useLocalIdentity !== false;
   const localIdentity = useLocalIdentity
-    ? ensureLocalSigningIdentity(opts.identityName ?? DEFAULT_LOCAL_SIGNING_IDENTITY)
+    ? opts.preparedIdentity ?? ensureLocalSigningIdentity(opts.identityName ?? DEFAULT_LOCAL_SIGNING_IDENTITY)
     : null;
   const signingIdentity = localIdentity?.hash ?? "-";
 
@@ -85,6 +92,22 @@ export function adHocSign(appRoot: string): void {
   signCodexApp(appRoot, { useLocalIdentity: false });
 }
 
+export function prepareCodeSigning(opts: CodeSigningOptions = {}): PreparedSigningIdentity | null {
+  if (platform() !== "darwin") return null;
+
+  requireExecutable("codesign", "macOS codesign is required to re-sign Codex.app after patching.");
+  if (opts.useLocalIdentity === false) return null;
+
+  requireExecutable("security", "macOS security is required to find Codex++'s local signing identity.");
+
+  const identityName = opts.identityName ?? DEFAULT_LOCAL_SIGNING_IDENTITY;
+  const existing = findCodeSigningIdentity(identityName);
+  if (existing) return { ...existing, created: false };
+
+  requireExecutable("openssl", "macOS openssl is required to create Codex++'s local signing identity.");
+  return createLocalSigningIdentity(identityName);
+}
+
 function walkAndSign(root: string, signingIdentity: string): void {
   let entries: string[];
   try {
@@ -118,28 +141,13 @@ function walkAndSign(root: string, signingIdentity: string): void {
   }
 }
 
-interface LocalSigningIdentity {
-  name: string;
-  hash: string;
-  created: boolean;
+function ensureLocalSigningIdentity(identityName: string): PreparedSigningIdentity {
+  return prepareCodeSigning({ identityName }) ?? (() => {
+    throw new Error(`Local signing identity "${identityName}" is only available on macOS.`);
+  })();
 }
 
-function ensureLocalSigningIdentity(identityName: string): LocalSigningIdentity {
-  const existing = findCodeSigningIdentity(identityName);
-  if (existing) return { ...existing, created: false };
-
-  createLocalSigningIdentity(identityName);
-
-  const created = findCodeSigningIdentity(identityName);
-  if (!created) {
-    throw new Error(
-      `Created local signing certificate "${identityName}", but it was not found as a valid code signing identity.`,
-    );
-  }
-  return { ...created, created: true };
-}
-
-function findCodeSigningIdentity(identityName: string): Omit<LocalSigningIdentity, "created"> | null {
+function findCodeSigningIdentity(identityName: string): Omit<PreparedSigningIdentity, "created"> | null {
   const result = spawnSync("security", ["find-identity", "-v", "-p", "codesigning"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
@@ -148,13 +156,14 @@ function findCodeSigningIdentity(identityName: string): Omit<LocalSigningIdentit
   return parseCodeSigningIdentities(output).find((identity) => identity.name === identityName) ?? null;
 }
 
-function createLocalSigningIdentity(identityName: string): void {
+function createLocalSigningIdentity(identityName: string): PreparedSigningIdentity {
   const dir = mkdtempSync(join(tmpdir(), "codex-plusplus-signing-"));
   try {
     const configPath = join(dir, "openssl.cnf");
     const keyPath = join(dir, "identity.key");
     const certPath = join(dir, "identity.crt");
     const p12Path = join(dir, "identity.p12");
+    const keychain = defaultUserKeychain();
 
     writeFileSync(
       configPath,
@@ -217,6 +226,8 @@ function createLocalSigningIdentity(identityName: string): void {
     execFileSync("security", [
       "import",
       p12Path,
+      "-k",
+      keychain,
       "-P",
       "",
       "-T",
@@ -229,13 +240,42 @@ function createLocalSigningIdentity(identityName: string): void {
       "trustRoot",
       "-p",
       "codeSign",
+      "-k",
+      keychain,
       certPath,
     ], { stdio: "ignore" });
+
+    const created = findCodeSigningIdentity(identityName);
+    if (!created) {
+      throw new Error("created certificate was not found as a valid code signing identity");
+    }
+    return { ...created, created: true };
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     throw new Error(`Failed to create local signing identity "${identityName}": ${message}`);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function defaultUserKeychain(): string {
+  const result = spawnSync("security", ["default-keychain", "-d", "user"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+  if (result.status !== 0 || !output) {
+    throw new Error("could not determine the user default keychain");
+  }
+  return output.replace(/^"|"$/g, "");
+}
+
+function requireExecutable(command: string, message: string): void {
+  const result = spawnSync("/bin/sh", ["-c", `command -v ${command}`], {
+    stdio: "ignore",
+  });
+  if (result.status !== 0) {
+    throw new Error(`[!] ${command} not installed\n\n${message}\nPaste this error into Codex if you need help.`);
   }
 }
 

--- a/packages/installer/src/codesign.ts
+++ b/packages/installer/src/codesign.ts
@@ -1,21 +1,37 @@
 /**
- * Ad-hoc code signing on macOS. After we mutate Info.plist or the
- * Electron Framework binary, the original signature is invalid. Re-signing
- * with the ad-hoc identity (`-`) makes Gatekeeper accept it on the
- * developer's own machine.
+ * Code signing on macOS. After we mutate Info.plist or the Electron Framework
+ * binary, the original signature is invalid. Re-signing with a stable local
+ * identity keeps macOS privacy permissions attached to the patched app across
+ * Codex++ repair runs on the same machine.
  *
  * `codesign --deep` does NOT recurse into `app.asar.unpacked` (it's not a
  * standard bundle layout), so native modules like `better-sqlite3.node` keep
- * their original Developer ID signature. Once the parent app is ad-hoc, the
- * dyld loader's Library Validation rejects the team-id mismatch and the
+ * their original Developer ID signature. Once the parent app is re-signed,
+ * the dyld loader's Library Validation rejects the team-id mismatch and the
  * native module fails to load. We work around this by walking
- * `app.asar.unpacked` ourselves and re-signing every Mach-O file ad-hoc
- * before signing the main bundle.
+ * `app.asar.unpacked` ourselves and re-signing every Mach-O file with the
+ * same identity before signing the main bundle.
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { platform } from "node:os";
+import { platform, tmpdir } from "node:os";
+
+export const DEFAULT_LOCAL_SIGNING_IDENTITY = "Codex++ Local Signing";
+
+export type SigningMode = "local-identity" | "adhoc";
+
+export interface CodeSigningResult {
+  mode: SigningMode;
+  identity: string;
+  identityHash?: string;
+  createdIdentity?: boolean;
+}
+
+export interface CodeSigningOptions {
+  useLocalIdentity?: boolean;
+  identityName?: string;
+}
 
 const MACHO_MAGICS = new Set([
   0xfeedface, // 32-bit
@@ -25,18 +41,24 @@ const MACHO_MAGICS = new Set([
   0xcefaedfe, // 32-bit LE
 ]);
 
-export function adHocSign(appRoot: string): void {
-  if (platform() !== "darwin") return;
+export function signCodexApp(appRoot: string, opts: CodeSigningOptions = {}): CodeSigningResult | null {
+  if (platform() !== "darwin") return null;
+
+  const useLocalIdentity = opts.useLocalIdentity !== false;
+  const localIdentity = useLocalIdentity
+    ? ensureLocalSigningIdentity(opts.identityName ?? DEFAULT_LOCAL_SIGNING_IDENTITY)
+    : null;
+  const signingIdentity = localIdentity?.hash ?? "-";
 
   // Step 1: pre-sign every Mach-O file under app.asar.unpacked. We do this
-  // before the bundle-level pass because once the framework is ad-hoc, every
-  // load must agree.
+  // before the bundle-level pass because once the framework is re-signed,
+  // every native load must agree.
   const resources = join(appRoot, "Contents", "Resources");
   for (const candidate of [
     join(resources, "app.asar.unpacked"),
   ]) {
     try {
-      walkAndSign(candidate);
+      walkAndSign(candidate, signingIdentity);
     } catch {
       // Directory may not exist; ignore.
     }
@@ -45,12 +67,25 @@ export function adHocSign(appRoot: string): void {
   // Step 2: sign the bundle itself with --deep (covers Frameworks, Helpers).
   execFileSync(
     "codesign",
-    ["--force", "--deep", "--sign", "-", appRoot],
+    ["--force", "--deep", "--sign", signingIdentity, appRoot],
     { stdio: "inherit" },
   );
+
+  return localIdentity
+    ? {
+        mode: "local-identity",
+        identity: localIdentity.name,
+        identityHash: localIdentity.hash,
+        createdIdentity: localIdentity.created,
+      }
+    : { mode: "adhoc", identity: "-" };
 }
 
-function walkAndSign(root: string): void {
+export function adHocSign(appRoot: string): void {
+  signCodexApp(appRoot, { useLocalIdentity: false });
+}
+
+function walkAndSign(root: string, signingIdentity: string): void {
   let entries: string[];
   try {
     entries = readdirSync(root);
@@ -66,7 +101,7 @@ function walkAndSign(root: string): void {
       continue;
     }
     if (st.isDirectory()) {
-      walkAndSign(full);
+      walkAndSign(full, signingIdentity);
       continue;
     }
     if (!st.isFile()) continue;
@@ -74,13 +109,144 @@ function walkAndSign(root: string): void {
     try {
       execFileSync(
         "codesign",
-        ["--force", "--sign", "-", "--preserve-metadata=entitlements,flags", full],
+        ["--force", "--sign", signingIdentity, "--preserve-metadata=entitlements,flags", full],
         { stdio: "ignore" },
       );
     } catch {
       // Some files (e.g., already-signed dSYMs) may refuse; not fatal.
     }
   }
+}
+
+interface LocalSigningIdentity {
+  name: string;
+  hash: string;
+  created: boolean;
+}
+
+function ensureLocalSigningIdentity(identityName: string): LocalSigningIdentity {
+  const existing = findCodeSigningIdentity(identityName);
+  if (existing) return { ...existing, created: false };
+
+  createLocalSigningIdentity(identityName);
+
+  const created = findCodeSigningIdentity(identityName);
+  if (!created) {
+    throw new Error(
+      `Created local signing certificate "${identityName}", but it was not found as a valid code signing identity.`,
+    );
+  }
+  return { ...created, created: true };
+}
+
+function findCodeSigningIdentity(identityName: string): Omit<LocalSigningIdentity, "created"> | null {
+  const result = spawnSync("security", ["find-identity", "-v", "-p", "codesigning"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  return parseCodeSigningIdentities(output).find((identity) => identity.name === identityName) ?? null;
+}
+
+function createLocalSigningIdentity(identityName: string): void {
+  const dir = mkdtempSync(join(tmpdir(), "codex-plusplus-signing-"));
+  try {
+    const configPath = join(dir, "openssl.cnf");
+    const keyPath = join(dir, "identity.key");
+    const certPath = join(dir, "identity.crt");
+    const p12Path = join(dir, "identity.p12");
+
+    writeFileSync(
+      configPath,
+      [
+        "[req]",
+        "distinguished_name=req_distinguished_name",
+        "x509_extensions=v3_req",
+        "prompt=no",
+        "",
+        "[req_distinguished_name]",
+        `CN=${identityName}`,
+        "",
+        "[v3_req]",
+        "basicConstraints=critical,CA:FALSE",
+        "keyUsage=critical,digitalSignature",
+        "extendedKeyUsage=codeSigning",
+        "",
+      ].join("\n"),
+    );
+
+    execFileSync("openssl", [
+      "req",
+      "-new",
+      "-newkey",
+      "rsa:2048",
+      "-x509",
+      "-sha256",
+      "-days",
+      "3650",
+      "-nodes",
+      "-config",
+      configPath,
+      "-keyout",
+      keyPath,
+      "-out",
+      certPath,
+    ], { stdio: "ignore" });
+
+    execFileSync("openssl", [
+      "pkcs12",
+      "-export",
+      "-inkey",
+      keyPath,
+      "-in",
+      certPath,
+      "-name",
+      identityName,
+      "-out",
+      p12Path,
+      "-keypbe",
+      "PBE-SHA1-3DES",
+      "-certpbe",
+      "PBE-SHA1-3DES",
+      "-macalg",
+      "sha1",
+      "-passout",
+      "pass:",
+    ], { stdio: "ignore" });
+
+    execFileSync("security", [
+      "import",
+      p12Path,
+      "-P",
+      "",
+      "-T",
+      "/usr/bin/codesign",
+    ], { stdio: "ignore" });
+
+    execFileSync("security", [
+      "add-trusted-cert",
+      "-r",
+      "trustRoot",
+      "-p",
+      "codeSign",
+      certPath,
+    ], { stdio: "ignore" });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`Failed to create local signing identity "${identityName}": ${message}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export function parseCodeSigningIdentities(output: string): Array<{ hash: string; name: string }> {
+  const identities: Array<{ hash: string; name: string }> = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^\s*\d+\)\s+([0-9A-Fa-f]{40})\s+"([^"]+)"/.exec(line);
+    if (!match) continue;
+    identities.push({ hash: match[1], name: match[2] });
+  }
+  return identities;
 }
 
 function isMachO(path: string): boolean {

--- a/packages/installer/src/commands/install.ts
+++ b/packages/installer/src/commands/install.ts
@@ -8,7 +8,7 @@ import { ensureUserPaths } from "../paths.js";
 import { backupOnce, patchAsar, readHeaderHash } from "../asar.js";
 import { setIntegrity, getIntegrity } from "../integrity.js";
 import { writeFuse } from "../fuses.js";
-import { adHocSign, clearQuarantine, signatureInfo } from "../codesign.js";
+import { clearQuarantine, signCodexApp, signatureInfo } from "../codesign.js";
 import { readPlist } from "../plist.js";
 import { writeState } from "../state.js";
 import { installWatcher, type WatcherKind } from "../watcher.js";
@@ -24,6 +24,7 @@ interface Opts {
   app?: string;
   fuse?: boolean; // sade --no-fuse → fuse: false
   resign?: boolean;
+  localSigning?: boolean;
   watcher?: boolean;
   watcherKind?: WatcherKind;
   quiet?: boolean;
@@ -36,13 +37,14 @@ const assetsDir = resolve(here, "..", "..", "assets");
 export async function install(opts: Opts = {}): Promise<void> {
   const fuseFlip = opts.fuse !== false;
   const resign = opts.resign !== false;
+  const localSigning = opts.localSigning !== false;
   const wantWatcher = opts.watcher !== false;
   const wantDefaultTweaks = opts.defaultTweaks !== false;
 
   const step = makeStepper(opts.quiet === true);
   const codex = locateCodex(opts.app);
   step(`Located Codex at ${kleur.cyan(codex.appRoot)}`);
-  preflightSystemTools(codex.platform, resign, codex.metaPath !== null);
+  preflightSystemTools(codex.platform, resign, localSigning, codex.metaPath !== null);
 
   // Pre-flight: try to create+remove a probe file inside the app bundle. This
   // surfaces macOS App Management TCC denials BEFORE we touch anything, and
@@ -108,11 +110,23 @@ export async function install(opts: Opts = {}): Promise<void> {
 
   // 6. Re-sign on macOS.
   let resigned = false;
+  let signingMode: "local-identity" | "adhoc" | undefined;
+  let signingIdentity: string | undefined;
+  let signingIdentityHash: string | undefined;
   if (resign && codex.platform === "darwin") {
     clearQuarantine(codex.appRoot);
-    adHocSign(codex.appRoot);
+    const signing = signCodexApp(codex.appRoot, { useLocalIdentity: localSigning });
     resigned = true;
-    step("Re-signed ad-hoc");
+    signingMode = signing?.mode;
+    signingIdentity = signing?.identity;
+    signingIdentityHash = signing?.identityHash;
+    if (signing?.mode === "local-identity") {
+      step(
+        `${signing.createdIdentity ? "Created and used" : "Used"} local signing identity ${kleur.cyan(signing.identity)}`,
+      );
+    } else {
+      step("Re-signed ad-hoc");
+    }
   }
 
   // 7. Auto-repair watcher.
@@ -143,6 +157,9 @@ export async function install(opts: Opts = {}): Promise<void> {
     codexBundleId: codex.bundleId,
     fuseFlipped,
     resigned,
+    signingMode,
+    signingIdentity,
+    signingIdentityHash,
     originalEntryPoint: originalEntry,
     watcher,
   });
@@ -304,9 +321,13 @@ function preflightWritable(targetDir: string, platform: string): void {
   }
 }
 
-function preflightSystemTools(platform: string, resign: boolean, hasPlist: boolean): void {
+function preflightSystemTools(platform: string, resign: boolean, localSigning: boolean, hasPlist: boolean): void {
   if (platform !== "darwin") return;
   if (resign) requireCommand("codesign", "macOS codesign is required to re-sign Codex.app after patching.");
+  if (resign && localSigning) {
+    requireCommand("openssl", "macOS openssl is required to create Codex++'s local signing identity.");
+    requireCommand("security", "macOS security is required to create and find Codex++'s local signing identity.");
+  }
   if (hasPlist) requireCommand("plutil", "macOS plutil is required to update Codex.app's Info.plist.");
 }
 

--- a/packages/installer/src/commands/install.ts
+++ b/packages/installer/src/commands/install.ts
@@ -8,7 +8,7 @@ import { ensureUserPaths } from "../paths.js";
 import { backupOnce, patchAsar, readHeaderHash } from "../asar.js";
 import { setIntegrity, getIntegrity } from "../integrity.js";
 import { writeFuse } from "../fuses.js";
-import { clearQuarantine, signCodexApp, signatureInfo } from "../codesign.js";
+import { clearQuarantine, prepareCodeSigning, signCodexApp, signatureInfo } from "../codesign.js";
 import { readPlist } from "../plist.js";
 import { writeState } from "../state.js";
 import { installWatcher, type WatcherKind } from "../watcher.js";
@@ -44,7 +44,10 @@ export async function install(opts: Opts = {}): Promise<void> {
   const step = makeStepper(opts.quiet === true);
   const codex = locateCodex(opts.app);
   step(`Located Codex at ${kleur.cyan(codex.appRoot)}`);
-  preflightSystemTools(codex.platform, resign, localSigning, codex.metaPath !== null);
+  preflightSystemTools(codex.platform, resign, codex.metaPath !== null);
+  const preparedSigning = resign && codex.platform === "darwin"
+    ? prepareCodeSigning({ useLocalIdentity: localSigning })
+    : null;
 
   // Pre-flight: try to create+remove a probe file inside the app bundle. This
   // surfaces macOS App Management TCC denials BEFORE we touch anything, and
@@ -115,7 +118,10 @@ export async function install(opts: Opts = {}): Promise<void> {
   let signingIdentityHash: string | undefined;
   if (resign && codex.platform === "darwin") {
     clearQuarantine(codex.appRoot);
-    const signing = signCodexApp(codex.appRoot, { useLocalIdentity: localSigning });
+    const signing = signCodexApp(codex.appRoot, {
+      useLocalIdentity: localSigning,
+      preparedIdentity: preparedSigning,
+    });
     resigned = true;
     signingMode = signing?.mode;
     signingIdentity = signing?.identity;
@@ -321,13 +327,9 @@ function preflightWritable(targetDir: string, platform: string): void {
   }
 }
 
-function preflightSystemTools(platform: string, resign: boolean, localSigning: boolean, hasPlist: boolean): void {
+function preflightSystemTools(platform: string, resign: boolean, hasPlist: boolean): void {
   if (platform !== "darwin") return;
   if (resign) requireCommand("codesign", "macOS codesign is required to re-sign Codex.app after patching.");
-  if (resign && localSigning) {
-    requireCommand("openssl", "macOS openssl is required to create Codex++'s local signing identity.");
-    requireCommand("security", "macOS security is required to create and find Codex++'s local signing identity.");
-  }
   if (hasPlist) requireCommand("plutil", "macOS plutil is required to update Codex.app's Info.plist.");
 }
 

--- a/packages/installer/src/commands/repair.ts
+++ b/packages/installer/src/commands/repair.ts
@@ -134,6 +134,7 @@ export async function repair(opts: Opts = {}): Promise<void> {
     app: opts.app ?? state?.appRoot,
     fuse: state?.fuseFlipped ?? true,
     resign: state?.resigned ?? true,
+    localSigning: state?.signingMode !== "adhoc",
     watcher: state?.watcher === "none" ? false : true,
     watcherKind: state?.watcher,
     quiet: opts.quiet,

--- a/packages/installer/src/commands/repair.ts
+++ b/packages/installer/src/commands/repair.ts
@@ -134,7 +134,7 @@ export async function repair(opts: Opts = {}): Promise<void> {
     app: opts.app ?? state?.appRoot,
     fuse: state?.fuseFlipped ?? true,
     resign: state?.resigned ?? true,
-    localSigning: state?.signingMode !== "adhoc",
+    localSigning: state ? state.signingMode === "local-identity" : true,
     watcher: state?.watcher === "none" ? false : true,
     watcherKind: state?.watcher,
     quiet: opts.quiet,

--- a/packages/installer/src/commands/status.ts
+++ b/packages/installer/src/commands/status.ts
@@ -34,6 +34,8 @@ export async function status(): Promise<void> {
   if (state.codexBundleId) console.log(`  bundle id:    ${state.codexBundleId}`);
   console.log(`  fuse flipped: ${state.fuseFlipped}`);
   console.log(`  resigned:     ${state.resigned}`);
+  if (state.signingMode) console.log(`  sign mode:    ${state.signingMode}`);
+  if (state.signingIdentity) console.log(`  sign identity: ${state.signingIdentity}`);
   console.log(`  watcher:      ${state.watcher}`);
   console.log();
 

--- a/packages/installer/src/commands/uninstall.ts
+++ b/packages/installer/src/commands/uninstall.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { locateCodex } from "../platform.js";
 import { ensureUserPaths } from "../paths.js";
 import { readState } from "../state.js";
-import { signCodexApp } from "../codesign.js";
+import { prepareCodeSigning, signCodexApp } from "../codesign.js";
 import { uninstallWatcher } from "../watcher.js";
 
 interface Opts {
@@ -20,6 +20,10 @@ export async function uninstall(opts: Opts = {}): Promise<void> {
   const backupAsarUnpacked = join(paths.backup, "app.asar.unpacked");
   const backupPlist = codex.metaPath ? join(paths.backup, "Info.plist") : null;
   const backupFramework = join(paths.backup, "Electron Framework");
+  const useLocalIdentity = state?.signingMode !== "adhoc";
+  const preparedSigning = codex.platform === "darwin"
+    ? prepareCodeSigning({ useLocalIdentity })
+    : null;
 
   if (!existsSync(backupAsar)) {
     console.error(
@@ -41,7 +45,7 @@ export async function uninstall(opts: Opts = {}): Promise<void> {
   console.log(kleur.green("Restored Codex.app from backup."));
 
   if (codex.platform === "darwin") {
-    signCodexApp(codex.appRoot, { useLocalIdentity: state?.signingMode !== "adhoc" });
+    signCodexApp(codex.appRoot, { useLocalIdentity, preparedIdentity: preparedSigning });
     console.log(kleur.green("Re-signed restored bundle."));
   }
 

--- a/packages/installer/src/commands/uninstall.ts
+++ b/packages/installer/src/commands/uninstall.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { locateCodex } from "../platform.js";
 import { ensureUserPaths } from "../paths.js";
 import { readState } from "../state.js";
-import { adHocSign } from "../codesign.js";
+import { signCodexApp } from "../codesign.js";
 import { uninstallWatcher } from "../watcher.js";
 
 interface Opts {
@@ -41,7 +41,7 @@ export async function uninstall(opts: Opts = {}): Promise<void> {
   console.log(kleur.green("Restored Codex.app from backup."));
 
   if (codex.platform === "darwin") {
-    adHocSign(codex.appRoot);
+    signCodexApp(codex.appRoot, { useLocalIdentity: state?.signingMode !== "adhoc" });
     console.log(kleur.green("Re-signed restored bundle."));
   }
 

--- a/packages/installer/src/commands/uninstall.ts
+++ b/packages/installer/src/commands/uninstall.ts
@@ -20,10 +20,6 @@ export async function uninstall(opts: Opts = {}): Promise<void> {
   const backupAsarUnpacked = join(paths.backup, "app.asar.unpacked");
   const backupPlist = codex.metaPath ? join(paths.backup, "Info.plist") : null;
   const backupFramework = join(paths.backup, "Electron Framework");
-  const useLocalIdentity = state?.signingMode !== "adhoc";
-  const preparedSigning = codex.platform === "darwin"
-    ? prepareCodeSigning({ useLocalIdentity })
-    : null;
 
   if (!existsSync(backupAsar)) {
     console.error(
@@ -31,6 +27,11 @@ export async function uninstall(opts: Opts = {}): Promise<void> {
     );
     process.exit(1);
   }
+
+  const useLocalIdentity = state?.signingMode === "local-identity";
+  const preparedSigning = codex.platform === "darwin"
+    ? prepareCodeSigning({ useLocalIdentity })
+    : null;
 
   cpSync(backupAsar, codex.asarPath);
   if (existsSync(backupAsarUnpacked)) {

--- a/packages/installer/src/state.ts
+++ b/packages/installer/src/state.ts
@@ -21,8 +21,14 @@ export interface InstallerState {
   codexBundleId?: string | null;
   /** Whether we flipped the Electron fuse. */
   fuseFlipped: boolean;
-  /** Whether we re-signed ad-hoc. */
+  /** Whether we re-signed the patched app. */
   resigned: boolean;
+  /** Signing mode used for the patched app. Older installs may not have this. */
+  signingMode?: "local-identity" | "adhoc";
+  /** Common name or ad-hoc marker used for the last signing pass. */
+  signingIdentity?: string;
+  /** SHA-1 hash of the local code signing identity, when applicable. */
+  signingIdentityHash?: string;
   /** Original entry point ("main" field) of the asar's package.json. */
   originalEntryPoint: string;
   /** Watcher install method, if any. */

--- a/packages/installer/test/codesign.test.ts
+++ b/packages/installer/test/codesign.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseCodeSigningIdentities } from "../src/codesign";
+
+test("parseCodeSigningIdentities extracts valid code signing identities", () => {
+  const identities = parseCodeSigningIdentities(`
+  1) ABCDEF1234567890ABCDEF1234567890ABCDEF12 "Codex++ Local Signing"
+  2) 0123456789abcdef0123456789abcdef01234567 "Apple Development: Example"
+     2 valid identities found
+`);
+
+  assert.deepEqual(identities, [
+    {
+      hash: "ABCDEF1234567890ABCDEF1234567890ABCDEF12",
+      name: "Codex++ Local Signing",
+    },
+    {
+      hash: "0123456789abcdef0123456789abcdef01234567",
+      name: "Apple Development: Example",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

- create/reuse a per-machine `Codex++ Local Signing` code-signing identity on macOS
- sign patched Mach-O files and the Codex.app bundle with that stable identity by default
- keep ad hoc signing available with `--no-local-signing` and preserve that mode on repair
- record/report signing mode in installer state and update docs

Closes #23.

## Testing

- `npm run build`
- `npm test`