### PR TITLE
[codex] Fix documented CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ To revert:
 codexplusplus uninstall
 ```
 
-Other commands: `status`, `doctor`, `repair`, `tweaks list`, `tweaks open` (opens user tweaks dir).
+Other commands: `status`, `doctor`, `repair`, `update-codex`, `create-tweak`,
+`validate-tweak`, `dev`, and `safe-mode`.
 
 ### Updating Codex on macOS
 


### PR DESCRIPTION
## Summary

- Replace README references to unsupported `tweaks list` and `tweaks open` commands.
- Document the CLI commands currently registered by `packages/installer/src/cli.ts`.

## Why

After installing Codex++, `codexplusplus tweaks list` returns `Invalid command: tweaks list`. The README lists commands that are not exposed by the current CLI.

## Validation

- Checked `packages/installer/src/cli.ts` for registered commands.
- Searched the docs for remaining `tweaks list` and `tweaks open` references.

No code changes.