### PR TITLE
[codex] Fix watcher repair while Codex is running

### DIFF
--- a/packages/installer/src/commands/repair.ts
+++ b/packages/installer/src/commands/repair.ts
@@ -131,7 +131,15 @@ export async function repair(opts: Opts = {}): Promise<void> {
     const codex = locateCodex(opts.app ?? state?.appRoot);
     repairedAppRoot = codex.appRoot;
     codexWasRunning = isCodexRunning(codex.appRoot);
-    if (codexWasRunning && process.platform === "darwin" && promptRestartCodexToRepatch(codex.appRoot)) {
+    if (shouldPatchWhileCodexRuns({
+      codexWasRunning,
+      watcherRepair: isWatcherRepair(opts),
+      platform: process.platform,
+    })) {
+      if (!opts.quiet) {
+        console.log(kleur.yellow("Codex is running; patching the app on disk and prompting for restart after repair."));
+      }
+    } else if (codexWasRunning && process.platform === "darwin" && promptRestartCodexToRepatch(codex.appRoot)) {
       reopenAfterRepair = true;
       codexWasRunning = false;
     } else if (codexWasRunning && process.platform === "darwin") {
@@ -221,6 +229,14 @@ function settleOptions(opts: Opts, updateModeFile: string): SettleOptions {
 
 function isWatcherRepair(opts: Opts): boolean {
   return opts.watcher === true || process.env.CODEX_PLUSPLUS_WATCHER === "1";
+}
+
+export function shouldPatchWhileCodexRuns(opts: {
+  codexWasRunning: boolean;
+  watcherRepair: boolean;
+  platform: NodeJS.Platform;
+}): boolean {
+  return opts.codexWasRunning && opts.watcherRepair && opts.platform === "darwin";
 }
 
 async function waitForMacAppUpdateToSettle(appRoot: string | undefined, opts: SettleOptions = {}): Promise<void> {

--- a/packages/installer/test/repair-running-codex.test.ts
+++ b/packages/installer/test/repair-running-codex.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shouldPatchWhileCodexRuns } from "../src/commands/repair";
+
+test("watcher repair patches the app on disk even when Codex is running", () => {
+  assert.equal(
+    shouldPatchWhileCodexRuns({
+      codexWasRunning: true,
+      watcherRepair: true,
+      platform: "darwin",
+    }),
+    true,
+  );
+});
+
+test("interactive repair still prompts before patching a running Codex app", () => {
+  assert.equal(
+    shouldPatchWhileCodexRuns({
+      codexWasRunning: true,
+      watcherRepair: false,
+      platform: "darwin",
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- allow watcher-triggered repair to patch Codex.app on disk even when Codex is currently running
- keep interactive repair behavior unchanged: it still asks before repatching a running macOS app
- add regression tests for watcher vs interactive running-app repair behavior

## Root cause
After a Codex app update, the official app bundle replaces the patched app.asar and removes the Codex++ loader. The watcher then sees Codex already running without Codex++; the current repair path can postpone before writing the loader back, so the app stays unpatched even after restart attempts.

Watcher repair is better handled by repairing the app on disk first, then asking the user to restart so the already-running process can load the patched app on next launch.

## Validation
- `node --import tsx --test packages/installer/test/repair-running-codex.test.ts`
- `npm test`
- `npm run build`

Related: #251, #253