### PR TITLE
Fix Windows Store desktop executable detection

### DIFF
--- a/packages/installer/src/platform.ts
+++ b/packages/installer/src/platform.ts
@@ -306,6 +306,10 @@ function isWinCodexRoot(appRoot: string): boolean {
 
 function findWinExecutable(appRoot: string): string {
   try {
+    // Newer Microsoft Store builds ship a small Codex.exe helper alongside
+    // ChatGPT.exe, which is the actual Electron desktop application.
+    const chatGpt = join(appRoot, "ChatGPT.exe");
+    if (existsSync(chatGpt)) return chatGpt;
     const exe = readdirSync(appRoot).find((name) => /\.exe$/i.test(name) && /\bcodex\b/i.test(name));
     if (exe) return join(appRoot, exe);
   } catch {}

--- a/packages/installer/test/platform.test.ts
+++ b/packages/installer/test/platform.test.ts
@@ -42,6 +42,24 @@ test("locateCodex reads beta bundle metadata from override path on macOS", { ski
   }
 });
 
+test("locateCodex prefers the Store desktop executable over the Codex helper on Windows", { skip: process.platform !== "win32" }, () => {
+  const root = mkdtempSync(join(tmpdir(), "codexpp-platform-"));
+  try {
+    const app = join(root, "OpenAI.Codex", "app");
+    mkdirSync(join(app, "resources"), { recursive: true });
+    writeFileSync(join(app, "resources", "app.asar"), "");
+    writeFileSync(join(app, "ChatGPT.exe"), "desktop");
+    writeFileSync(join(app, "Codex.exe"), "helper");
+
+    const codex = locateCodex(app);
+    assert.equal(codex.executable, join(app, "ChatGPT.exe"));
+    assert.equal(codex.electronBinary, join(app, "ChatGPT.exe"));
+    assert.equal(codex.appName, "ChatGPT");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("resolveLinuxInstall supports am-will codex-app install directory", () => {
   const root = mkdtempSync(join(tmpdir(), "codexpp-platform-"));
   try {


### PR DESCRIPTION
## Summary

- Prefer `ChatGPT.exe` when selecting the Windows desktop application executable.
- Keep the existing `Codex.exe` fallback for older installations.
- Add a regression test covering Store-style layouts that contain both the desktop executable and a helper named `Codex.exe`.

## Context

The current Windows Store package still uses the `OpenAI.Codex` package identity, but its application entry point is `app/ChatGPT.exe`. The same directory can also contain a smaller helper named `Codex.exe`. Existing discovery selects the first executable whose name contains `Codex`, so generated Codex++ launchers can target the helper and exit without opening the desktop app.

This PR is intentionally narrow: it fixes Windows launcher executable selection only. It is unrelated to the in-app browser crash, and it does not attempt the broader cross-platform Codex-to-ChatGPT desktop-app migration.

## Validation

- Targeted Windows platform regression test passes.
- `tsc -p packages/installer/tsconfig.json --noEmit` passes.